### PR TITLE
Fixes for Channel list and details

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsActivity.java
@@ -28,7 +28,8 @@ public class ChannelDetailsActivity extends BaseActivity {
 
     @AutoBundleField String channelId;
 
-    @AutoBundleField(required = false) boolean scrollToCourses = false;
+    //-1 do not scroll to Course
+    @AutoBundleField(required = false) int scrollToCoursePosition = -1;
 
     @BindView(R.id.toolbar_image) ImageView imageView;
     @BindView(R.id.appbar) AppBarLayout appBarLayout;
@@ -63,7 +64,7 @@ public class ChannelDetailsActivity extends BaseActivity {
 
         FragmentManager fragmentManager = getSupportFragmentManager();
         if (fragmentManager.findFragmentByTag(tag) == null) {
-            final ChannelDetailsFragment fragment = ChannelDetailsFragmentAutoBundle.builder(channelId).scrollToCourses(scrollToCourses).build();
+            final ChannelDetailsFragment fragment = ChannelDetailsFragmentAutoBundle.builder(channelId).scrollToCoursePosition(scrollToCoursePosition).build();
             FragmentTransaction transaction = fragmentManager.beginTransaction();
             transaction.replace(R.id.content, fragment, tag);
             transaction.commit();

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.java
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.java
@@ -42,7 +42,8 @@ public class ChannelDetailsFragment extends LoadingStatePresenterFragment<Channe
 
     @AutoBundleField String channelId;
 
-    @AutoBundleField (required = false) boolean scrollToCourses = false;
+    //-1 do not scroll to Course
+    @AutoBundleField(required = false) int scrollToCoursePosition = -1;
 
     @BindView(R.id.layout_header) FrameLayout layoutHeader;
     @BindView(R.id.image_channel) ImageView imageChannel;
@@ -134,23 +135,29 @@ public class ChannelDetailsFragment extends LoadingStatePresenterFragment<Channe
     public void setupView(Channel channel) {
         if (getActivity() instanceof ChannelDetailsActivity) {
             layoutHeader.setVisibility(View.GONE);
-        }
-        else {
+        } else {
             GlideApp.with(this).load(channel.imageUrl).into(imageChannel);
             textTitle.setText(channel.title);
         }
 
-        if(courseListAdapter != null)
+        if (courseListAdapter != null)
             courseListAdapter.setButtonColor(channel.getColorOrDefault());
     }
 
     @Override
     public void showCourseList(SectionList<String, List<Course>> courses) {
-        if(courseListAdapter != null)
+        if (courseListAdapter != null)
             courseListAdapter.update(courses);
 
-        if(scrollToCourses)
-            courseList.scrollToPosition(1);
+        if (scrollToCoursePosition >= 0) {
+            try {
+                ChannelDetailsActivity a = ((ChannelDetailsActivity) getActivity());
+                if (a != null)
+                    a.appBarLayout.setExpanded(false);
+                courseList.smoothScrollToPosition(scrollToCoursePosition + 3);
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/de/xikolo/controllers/main/ChannelListAdapter.java
+++ b/app/src/main/java/de/xikolo/controllers/main/ChannelListAdapter.java
@@ -32,10 +32,10 @@ public class ChannelListAdapter extends RecyclerView.Adapter<ChannelListAdapter.
 
     public static final int PREVIEW_COURSES_COUNT = 7;
 
-    private List<Channel> channelList =  new ArrayList<>();
+    private List<Channel> channelList = new ArrayList<>();
     private OnChannelCardClickListener callback;
 
-    public ChannelListAdapter(OnChannelCardClickListener callback){
+    public ChannelListAdapter(OnChannelCardClickListener callback) {
         this.callback = callback;
     }
 
@@ -77,7 +77,7 @@ public class ChannelListAdapter extends RecyclerView.Adapter<ChannelListAdapter.
         holder.buttonChannelCourses.setOnClickListener(v -> callback.onChannelClicked(channel.id));
         holder.layout.setOnClickListener(v -> callback.onChannelClicked(channel.id));
 
-        if(channel.imageUrl != null)
+        if (channel.imageUrl != null)
             GlideApp.with(App.getInstance()).load(channel.imageUrl).into(holder.imageView);
         else
             holder.imageView.setVisibility(View.GONE);
@@ -124,18 +124,20 @@ public class ChannelListAdapter extends RecyclerView.Adapter<ChannelListAdapter.
                 ImageView imageView = listItem.findViewById(R.id.imageView);
                 GlideApp.with(App.getInstance()).load(course.imageUrl).into(imageView);
 
-                listItem.setOnClickListener(v -> callback.onCourseClicked(course.id));
+                listItem.setOnClickListener(v -> callback.onCourseClicked(course));
 
                 holder.scrollContainer.addView(listItem);
             }
 
             if (courseList.size() > PREVIEW_COURSES_COUNT) {
-                CardView showMoreButton = (CardView) LayoutInflater.from(App.getInstance()).inflate(R.layout.item_channel_list_scroll_more, holder.scrollContainer, false);
+                CardView showMoreCard = (CardView) LayoutInflater.from(App.getInstance()).inflate(R.layout.item_channel_list_scroll_more, holder.scrollContainer, false);
 
-                showMoreButton.setCardBackgroundColor(channelColor);
-                showMoreButton.setOnClickListener(v -> callback.onMoreCoursesClicked(channel.id));
+                ImageView imageView = showMoreCard.findViewById(R.id.imageView);
+                GlideApp.with(App.getInstance()).load(channel.imageUrl).into(imageView);
 
-                holder.scrollContainer.addView(showMoreButton);
+                showMoreCard.setOnClickListener(v -> callback.onMoreCoursesClicked(channel.id, courseCount));
+
+                holder.scrollContainer.addView(showMoreCard);
             }
         });
     }
@@ -144,9 +146,9 @@ public class ChannelListAdapter extends RecyclerView.Adapter<ChannelListAdapter.
 
         void onChannelClicked(String channelId);
 
-        void onCourseClicked(String courseId);
+        void onCourseClicked(Course course);
 
-        void onMoreCoursesClicked(String channelId);
+        void onMoreCoursesClicked(String channelId, int scrollPosition);
     }
 
     static class ChannelViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/de/xikolo/controllers/main/ChannelListAdapter.java
+++ b/app/src/main/java/de/xikolo/controllers/main/ChannelListAdapter.java
@@ -1,6 +1,5 @@
 package de.xikolo.controllers.main;
 
-import android.support.v7.widget.CardView;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -130,7 +129,7 @@ public class ChannelListAdapter extends RecyclerView.Adapter<ChannelListAdapter.
             }
 
             if (courseList.size() > PREVIEW_COURSES_COUNT) {
-                CardView showMoreCard = (CardView) LayoutInflater.from(App.getInstance()).inflate(R.layout.item_channel_list_scroll_more, holder.scrollContainer, false);
+                View showMoreCard = LayoutInflater.from(App.getInstance()).inflate(R.layout.item_channel_list_scroll_more, holder.scrollContainer, false);
 
                 ImageView imageView = showMoreCard.findViewById(R.id.imageView);
                 GlideApp.with(App.getInstance()).load(channel.imageUrl).into(imageView);
@@ -138,6 +137,7 @@ public class ChannelListAdapter extends RecyclerView.Adapter<ChannelListAdapter.
                 showMoreCard.setOnClickListener(v -> callback.onMoreCoursesClicked(channel.id, courseCount));
 
                 holder.scrollContainer.addView(showMoreCard);
+                holder.scrollContainer.setPadding(holder.scrollContainer.getPaddingLeft(), holder.scrollContainer.getPaddingTop(), 0, holder.scrollContainer.getPaddingBottom());
             }
         });
     }

--- a/app/src/main/java/de/xikolo/controllers/main/ChannelListFragment.java
+++ b/app/src/main/java/de/xikolo/controllers/main/ChannelListFragment.java
@@ -19,10 +19,12 @@ import butterknife.BindView;
 import de.xikolo.App;
 import de.xikolo.R;
 import de.xikolo.controllers.channels.ChannelDetailsActivityAutoBundle;
+import de.xikolo.controllers.course.CourseActivityAutoBundle;
 import de.xikolo.controllers.course.CourseDetailsActivityAutoBundle;
 import de.xikolo.events.LoginEvent;
 import de.xikolo.events.LogoutEvent;
 import de.xikolo.models.Channel;
+import de.xikolo.models.Course;
 import de.xikolo.presenters.base.PresenterFactory;
 import de.xikolo.presenters.main.ChannelListPresenter;
 import de.xikolo.presenters.main.ChannelListPresenterFactory;
@@ -63,13 +65,13 @@ public class ChannelListFragment extends MainFragment<ChannelListPresenter, Chan
             }
 
             @Override
-            public void onCourseClicked(String courseId) {
-                showCourse(courseId);
+            public void onCourseClicked(Course course) {
+                showCourse(course);
             }
 
             @Override
-            public void onMoreCoursesClicked(String channelId) {
-                showChannelCourses(channelId);
+            public void onMoreCoursesClicked(String channelId, int scrollPosition) {
+                showChannelCourses(channelId, scrollPosition);
             }
         });
 
@@ -105,14 +107,18 @@ public class ChannelListFragment extends MainFragment<ChannelListPresenter, Chan
     }
 
     @Override
-    public void showCourse(String courseId) {
-        Intent intent = CourseDetailsActivityAutoBundle.builder(courseId).build(App.getInstance());
+    public void showCourse(Course course) {
+        Intent intent;
+        if (course.isEnrolled())
+            intent = CourseActivityAutoBundle.builder().courseId(course.id).build(App.getInstance());
+        else
+            intent = CourseDetailsActivityAutoBundle.builder(course.id).build(App.getInstance());
         startActivity(intent);
     }
 
     @Override
-    public void showChannelCourses(String channelId) {
-        Intent intent = ChannelDetailsActivityAutoBundle.builder(channelId).scrollToCourses(true).build(App.getInstance());
+    public void showChannelCourses(String channelId, int scrollPosition) {
+        Intent intent = ChannelDetailsActivityAutoBundle.builder(channelId).scrollToCoursePosition(scrollPosition).build(App.getInstance());
         startActivity(intent);
     }
 

--- a/app/src/main/java/de/xikolo/presenters/main/ChannelListView.java
+++ b/app/src/main/java/de/xikolo/presenters/main/ChannelListView.java
@@ -3,6 +3,7 @@ package de.xikolo.presenters.main;
 import java.util.List;
 
 import de.xikolo.models.Channel;
+import de.xikolo.models.Course;
 import de.xikolo.presenters.base.LoadingStateView;
 
 public interface ChannelListView extends LoadingStateView {
@@ -11,7 +12,7 @@ public interface ChannelListView extends LoadingStateView {
 
     void showChannel(String channelId);
 
-    void showCourse(String courseId);
+    void showCourse(Course course);
 
-    void showChannelCourses(String courseId);
+    void showChannelCourses(String courseId, int coursePosition);
 }

--- a/app/src/main/res/layout/item_channel_list_scroll.xml
+++ b/app/src/main/res/layout/item_channel_list_scroll.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:res="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
     android:layout_width="240dp"
     android:layout_height="120dp"
@@ -23,8 +22,7 @@
             android:id="@+id/imageView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scaleType="centerCrop"
-            tools:src="@mipmap/ic_splash" />
+            android:scaleType="centerCrop" />
 
         <TextView
             android:id="@+id/textTitle"

--- a/app/src/main/res/layout/item_channel_list_scroll_more.xml
+++ b/app/src/main/res/layout/item_channel_list_scroll_more.xml
@@ -2,26 +2,45 @@
 <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:res="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"
-    android:layout_width="60dp"
-    android:layout_height="60dp"
-    android:layout_marginBottom="30dp"
-    android:layout_marginLeft="16dp"
-    android:layout_marginRight="16dp"
-    android:layout_marginTop="30dp"
+    android:layout_width="120dp"
+    android:layout_height="120dp"
+    android:layout_marginLeft="2dp"
+    android:layout_marginRight="2dp"
     android:clickable="true"
     android:focusable="true"
     android:foreground="?android:attr/selectableItemBackground"
-    res:cardBackgroundColor="@color/apptheme_main"
-    res:cardCornerRadius="30dp">
+    res:cardCornerRadius="2dp"
+    res:cardPreventCornerOverlap="true"
+    res:cardUseCompatPadding="true">
 
-    <TextView
-        android:id="@+id/textView"
+    <RelativeLayout
+        android:id="@+id/imageContainer"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:text="＋"
-        android:textColor="@color/white"
-        android:textSize="24dp"
-        android:textStyle="bold" />
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/imageView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop" />
+
+        <TextView
+            android:id="@+id/textTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:background="@drawable/scrim_bottom"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-medium"
+            android:maxLines="2"
+            android:paddingBottom="8dp"
+            android:paddingLeft="12dp"
+            android:paddingRight="12dp"
+            android:paddingTop="16sp"
+            android:text="@string/btn_channel_courses"
+            android:textColor="#FFFFFF"
+            android:textSize="16sp" />
+
+    </RelativeLayout>
 
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/item_channel_list_scroll_more.xml
+++ b/app/src/main/res/layout/item_channel_list_scroll_more.xml
@@ -1,46 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:res="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"
     android:layout_width="120dp"
     android:layout_height="120dp"
-    android:layout_marginLeft="2dp"
-    android:layout_marginRight="2dp"
     android:clickable="true"
-    android:focusable="true"
-    android:foreground="?android:attr/selectableItemBackground"
-    res:cardCornerRadius="2dp"
-    res:cardPreventCornerOverlap="true"
-    res:cardUseCompatPadding="true">
+    android:focusable="true">
 
-    <RelativeLayout
-        android:id="@+id/imageContainer"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+    <android.support.v7.widget.CardView
+        android:layout_width="122dp"
+        android:layout_height="120dp"
+        android:layout_marginLeft="2dp"
+        android:clickable="false"
+        android:focusable="true"
+        android:foreground="?android:attr/selectableItemBackground"
+        res:cardCornerRadius="2dp"
+        res:cardPreventCornerOverlap="true"
+        res:cardUseCompatPadding="true">
 
-        <ImageView
-            android:id="@+id/imageView"
+        <RelativeLayout
+            android:id="@+id/imageContainer"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="centerCrop" />
+            android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/textTitle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:background="@drawable/scrim_bottom"
-            android:ellipsize="end"
-            android:fontFamily="sans-serif-medium"
-            android:maxLines="2"
-            android:paddingBottom="8dp"
-            android:paddingLeft="12dp"
-            android:paddingRight="12dp"
-            android:paddingTop="16sp"
-            android:text="@string/btn_channel_courses"
-            android:textColor="#FFFFFF"
-            android:textSize="16sp" />
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="centerCrop" />
 
-    </RelativeLayout>
+            <TextView
+                android:id="@+id/textTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:background="@drawable/scrim_bottom"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif-medium"
+                android:maxLines="2"
+                android:paddingBottom="8dp"
+                android:paddingLeft="12dp"
+                android:paddingRight="12dp"
+                android:paddingTop="16sp"
+                android:text="@string/btn_channel_slider_more"
+                android:textColor="#FFFFFF"
+                android:textSize="16sp" />
 
-</android.support.v7.widget.CardView>
+        </RelativeLayout>
+
+    </android.support.v7.widget.CardView>
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -49,6 +49,7 @@
     <string name="btn_continue_course">Kurs fortsetzen</string>
     <string name="btn_course_details">Details zeigen</string>
     <string name="btn_channel_courses">Mehr anzeigen</string>
+    <string name="btn_channel_slider_more">Mehr Kurse anzeigen</string>
     <string name="btn_starts_soon">Kurs hat noch nicht begonnen</string>
     <string name="btn_display_issues">Darstellungsprobleme?</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="btn_continue_course">Continue course</string>
     <string name="btn_course_details">Show details</string>
     <string name="btn_channel_courses">Show more</string>
+    <string name="btn_channel_slider_more">Show more courses</string>
     <string name="btn_starts_soon">Course has not yet started</string>
     <string name="btn_play_cast">&#xe652;\n Play on Cast device</string>
     <string name="btn_display_issues">Display issues?</string>


### PR DESCRIPTION
Fixes:
- Course details instead of learning pane were opened upon click in Channel list slider although user was enrolled for this Course
- misleading "+" button at end of Channel list slider now replaced by card saying "show more"
- upon clicking this card, the toolbar is now collapsed and the screen is being scrolled to the element that would be next in the slider

![screen](https://user-images.githubusercontent.com/26904189/39667916-e98e385e-50c0-11e8-962b-ceff5d254b6d.png)
