### PR TITLE
Deprecate Android 4

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/dialogs/Android4DeprecatedDialog.kt
+++ b/app/src/main/java/de/xikolo/controllers/dialogs/Android4DeprecatedDialog.kt
@@ -1,0 +1,36 @@
+package de.xikolo.controllers.dialogs
+
+import android.app.Dialog
+import android.os.Bundle
+import android.support.v7.app.AlertDialog
+import de.xikolo.R
+import de.xikolo.controllers.dialogs.base.BaseDialogFragment
+
+class Android4DeprecatedDialog : BaseDialogFragment() {
+
+    companion object {
+        val TAG: String = Android4DeprecatedDialog::class.java.simpleName
+    }
+
+    var listener: Listener? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = AlertDialog.Builder(activity!!, R.style.AppTheme_Dialog)
+            .setTitle(
+                getString(R.string.dialog_android_4_deprecation_title)
+            )
+            .setMessage(
+                getString(R.string.dialog_android_4_deprecation_message)
+            )
+            .setPositiveButton(getString(R.string.ok)) { _, _ ->
+                listener?.onConfirmed()
+            }
+
+        return builder.create()
+    }
+
+    interface Listener {
+        fun onConfirmed()
+    }
+
+}

--- a/app/src/main/java/de/xikolo/controllers/dialogs/Android4UnsupportedDialog.kt
+++ b/app/src/main/java/de/xikolo/controllers/dialogs/Android4UnsupportedDialog.kt
@@ -1,0 +1,36 @@
+package de.xikolo.controllers.dialogs
+
+import android.app.Dialog
+import android.os.Bundle
+import android.support.v7.app.AlertDialog
+import de.xikolo.R
+import de.xikolo.controllers.dialogs.base.BaseDialogFragment
+
+class Android4UnsupportedDialog : BaseDialogFragment() {
+
+    companion object {
+        val TAG: String = Android4UnsupportedDialog::class.java.simpleName
+    }
+
+    var listener: Listener? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = AlertDialog.Builder(activity!!, R.style.AppTheme_Dialog)
+            .setTitle(
+                getString(R.string.dialog_android_4_unsupported_title)
+            )
+            .setMessage(
+                getString(R.string.dialog_android_4_unsupported_message)
+            )
+            .setNegativeButton(getString(R.string.dialog_android_4_unsupported_no)) { _, _ ->
+                listener?.onConfirmed()
+            }
+
+        return builder.create()
+    }
+
+    interface Listener {
+        fun onConfirmed()
+    }
+
+}

--- a/app/src/main/java/de/xikolo/controllers/main/SplashActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/SplashActivity.kt
@@ -2,12 +2,15 @@ package de.xikolo.controllers.main
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.support.v4.app.DialogFragment
 import android.support.v7.app.AppCompatActivity
 import de.xikolo.controllers.dialogs.*
 import de.xikolo.jobs.CheckHealthJob
 import de.xikolo.jobs.base.RequestJobCallback
+import de.xikolo.storages.ApplicationPreferences
+import de.xikolo.utils.DateUtil
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -47,7 +50,44 @@ class SplashActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        CheckHealthJob(healthCheckCallback).run()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            when {
+                DateUtil.isPast("2018-07-15T00:00:00.000") && !ApplicationPreferences().firstAndroid4DeprecationWarningShown -> {
+                    val dialog = Android4DeprecatedDialog()
+                    dialog.listener = object : Android4DeprecatedDialog.Listener {
+                        override fun onConfirmed() {
+                            CheckHealthJob(healthCheckCallback).run()
+                        }
+                    }
+                    showDialog(dialog, Android4DeprecatedDialog.TAG)
+                    ApplicationPreferences().firstAndroid4DeprecationWarningShown = true
+                }
+                DateUtil.isPast("2018-08-15T00:00:00.000") && !ApplicationPreferences().secondAndroid4DeprecationWarningShown -> {
+                    val dialog = Android4DeprecatedDialog()
+                    dialog.listener = object : Android4DeprecatedDialog.Listener {
+                        override fun onConfirmed() {
+                            CheckHealthJob(healthCheckCallback).run()
+                        }
+                    }
+                    showDialog(dialog, Android4DeprecatedDialog.TAG)
+                    ApplicationPreferences().secondAndroid4DeprecationWarningShown = true
+                }
+                DateUtil.isPast("2018-08-31T00:00:00.000") -> {
+                    val dialog = Android4UnsupportedDialog()
+                    dialog.listener = object : Android4UnsupportedDialog.Listener {
+                        override fun onConfirmed() {
+                            closeApp()
+                        }
+                    }
+                    showDialog(dialog, Android4DeprecatedDialog.TAG)
+                }
+                else -> {
+                    CheckHealthJob(healthCheckCallback).run()
+                }
+            }
+        } else {
+            CheckHealthJob(healthCheckCallback).run()
+        }
     }
 
     private fun showApiVersionExpiredDialog() {

--- a/app/src/main/java/de/xikolo/storages/ApplicationPreferences.kt
+++ b/app/src/main/java/de/xikolo/storages/ApplicationPreferences.kt
@@ -39,6 +39,14 @@ class ApplicationPreferences {
         get() = getBoolean(context.getString(R.string.preference_used_second_screen), false)
         set(value) = putBoolean(context.getString(R.string.preference_used_second_screen), value)
 
+    var firstAndroid4DeprecationWarningShown: Boolean
+        get() = getBoolean(context.getString(R.string.preference_first_android_4_deprecation_dialog), false)
+        set(value) = putBoolean(context.getString(R.string.preference_first_android_4_deprecation_dialog), value)
+
+    var secondAndroid4DeprecationWarningShown: Boolean
+        get() = getBoolean(context.getString(R.string.preference_second_android_4_deprecation_dialog), false)
+        set(value) = putBoolean(context.getString(R.string.preference_second_android_4_deprecation_dialog), value)
+
     private fun getBoolean(key: String, defValue: Boolean = true) = preferences.getBoolean(key, defValue)
 
     private fun putBoolean(key: String, value: Boolean) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -105,6 +105,12 @@
     <string name="dialog_server_error_message">Beim Kontaktieren des Servers ist ein Problem aufgetreten. Bitte versuche es später noch einmal.</string>
     <string name="dialog_server_error_no">Schließen</string>
 
+    <string name="dialog_android_4_deprecation_title">Android 4 Unterstützung wird eingestellt</string>
+    <string name="dialog_android_4_deprecation_message">Aus Sicherheitsgründen endet die Unterstützung für Android 4 am 31. August 2018. Danach wird die App nicht mehr funktionieren. Bitte aktualisieren Sie Ihr Gerät oder verwenden Sie stattdessen die Web-Version.</string>
+    <string name="dialog_android_4_unsupported_title">Android 4 Unterstützung wurde eingestellt</string>
+    <string name="dialog_android_4_unsupported_message">Aus Sicherheitsgründen wurde die Unterstützung für Android 4 beendet. Bitte aktualisieren Sie Ihr Gerät oder verwenden Sie stattdessen die Web-Version.</string>
+    <string name="dialog_android_4_unsupported_no">Schließen</string>
+
     <!-- -->
     <string name="title_activity_module">Module</string>
 

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -30,6 +30,9 @@
     <string name="preference_used_second_screen" translatable="false">used_second_screen</string>
     <string name="preference_dialog_second_screen" translatable="false">dialog_second_screen</string>
 
+    <string name="preference_first_android_4_deprecation_dialog" translatable="false">first_android_4_deprecation_dialog</string>
+    <string name="preference_second_android_4_deprecation_dialog" translatable="false">second_android_4_deprecation_dialog</string>
+
     <string name="duration" translatable="false">%1$02d:%2$02d</string>
 
     <string name="percentage" translatable="false">%1$d%%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,12 @@
     <string name="dialog_server_error_message">There was an issue while contacting the server. Please try again later.</string>
     <string name="dialog_server_error_no">Close</string>
 
+    <string name="dialog_android_4_deprecation_title">Android 4 support is discontinued</string>
+    <string name="dialog_android_4_deprecation_message">For security reasons, support for Android 4 ends on August 31, 2018. After that, the app will no longer work. Please upgrade your device or use the web version instead.</string>
+    <string name="dialog_android_4_unsupported_title">Android 4 support has been discontinued</string>
+    <string name="dialog_android_4_unsupported_message">For security reasons, support for Android 4 ended. Please upgrade your device or use the web version instead.</string>
+    <string name="dialog_android_4_unsupported_no">Close</string>
+
     <!-- -->
     <string name="title_activity_module">Module</string>
 
@@ -148,6 +154,7 @@
     <string name="or">or</string>
     <string name="login_sso">SSO</string>
     <string name="login_sso_hint">SSO Login</string>
+    <string name="ok">OK</string>
 
     <string name="self_test_points">%1$.1f of %2$.1f self-test points</string>
     <string name="assignments_points">%1$.1f of %2$.1f assignment points</string>


### PR DESCRIPTION
Android 4 doesn't support TLS1.2 with modern cyphers. Therefore, and because of the low usage numbers, we will deprecate it in 3 steps. This implements step 1:
*  display deprecation dialog for Android 4 devices (2 times)
*  lock app after deprecation date for Android 4 devices and show dialog

In step 2 after the deprecation date has passed, we will directly lock the app for Android 4 devices without any date check. This will be the last release with `minSdkVersion 16`. In step 3 we will increase the `minSdkVersion` to `21` and remove all the checks and dialogs. Thus, the apk from step 2 will be the last that will be delivered by the play store for Android 4 devices.