### PR TITLE
Fixes for channel's course list

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelCourseListAdapter.java
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelCourseListAdapter.java
@@ -28,9 +28,9 @@ public class ChannelCourseListAdapter extends BaseCourseListAdapter {
 
     public static final String TAG = ChannelCourseListAdapter.class.getSimpleName();
 
-    private static final int ITEM_VIEW_TYPE_META = 0;
-    private static final int ITEM_VIEW_TYPE_HEADER = 1;
-    private static final int ITEM_VIEW_TYPE_ITEM = 2;
+    public static final int ITEM_VIEW_TYPE_META = 0;
+    public static final int ITEM_VIEW_TYPE_HEADER = 1;
+    public static final int ITEM_VIEW_TYPE_ITEM = 2;
 
     private int channelColor = -1;
 

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.java
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.java
@@ -151,10 +151,19 @@ public class ChannelDetailsFragment extends LoadingStatePresenterFragment<Channe
 
         if (scrollToCoursePosition >= 0) {
             try {
-                ChannelDetailsActivity a = ((ChannelDetailsActivity) getActivity());
-                if (a != null)
-                    a.appBarLayout.setExpanded(false);
-                courseList.smoothScrollToPosition(scrollToCoursePosition + 3);
+                ChannelDetailsActivity activity = ((ChannelDetailsActivity) getActivity());
+                if (activity != null)
+                    activity.appBarLayout.setExpanded(false);
+
+                int headerCount = 0;
+                for(int i = 0; i < scrollToCoursePosition; i++){
+                    if(courseListAdapter.getItemViewType(i) == ChannelCourseListAdapter.ITEM_VIEW_TYPE_HEADER
+                        || courseListAdapter.getItemViewType(i) == ChannelCourseListAdapter.ITEM_VIEW_TYPE_META)
+                        headerCount++;
+                }
+
+                courseList.smoothScrollToPosition(scrollToCoursePosition + headerCount);
+                scrollToCoursePosition = -1;
             } catch (Exception ignored) {
             }
         }

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.java
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.java
@@ -89,25 +89,25 @@ public class ChannelDetailsFragment extends LoadingStatePresenterFragment<Channe
         courseList.setAdapter(courseListAdapter);
 
         courseList.addItemDecoration(new SpaceItemDecoration(
-                App.getInstance().getResources().getDimensionPixelSize(R.dimen.card_horizontal_margin),
-                App.getInstance().getResources().getDimensionPixelSize(R.dimen.card_vertical_margin),
-                false,
-                new SpaceItemDecoration.RecyclerViewInfo() {
-                    @Override
-                    public boolean isHeader(int position) {
-                        return courseListAdapter.isHeader(position);
-                    }
+            App.getInstance().getResources().getDimensionPixelSize(R.dimen.card_horizontal_margin),
+            App.getInstance().getResources().getDimensionPixelSize(R.dimen.card_vertical_margin),
+            false,
+            new SpaceItemDecoration.RecyclerViewInfo() {
+                @Override
+                public boolean isHeader(int position) {
+                    return courseListAdapter.isHeader(position);
+                }
 
-                    @Override
-                    public int getSpanCount() {
-                        return courseList.getSpanCount();
-                    }
+                @Override
+                public int getSpanCount() {
+                    return courseList.getSpanCount();
+                }
 
-                    @Override
-                    public int getItemCount() {
-                        return courseListAdapter.getItemCount();
-                    }
-                }));
+                @Override
+                public int getItemCount() {
+                    return courseListAdapter.getItemCount();
+                }
+            }));
     }
 
     @Override
@@ -156,10 +156,11 @@ public class ChannelDetailsFragment extends LoadingStatePresenterFragment<Channe
                     activity.appBarLayout.setExpanded(false);
 
                 int headerCount = 0;
-                for(int i = 0; i < scrollToCoursePosition; i++){
-                    if(courseListAdapter.getItemViewType(i) == ChannelCourseListAdapter.ITEM_VIEW_TYPE_HEADER
-                        || courseListAdapter.getItemViewType(i) == ChannelCourseListAdapter.ITEM_VIEW_TYPE_META)
+                for (int i = 0; i < scrollToCoursePosition; i++) {
+                    if (courseListAdapter.getItemViewType(i) == ChannelCourseListAdapter.ITEM_VIEW_TYPE_HEADER
+                        || courseListAdapter.getItemViewType(i) == ChannelCourseListAdapter.ITEM_VIEW_TYPE_META) {
                         headerCount++;
+                    }
                 }
 
                 courseList.smoothScrollToPosition(scrollToCoursePosition + headerCount);

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.java
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.java
@@ -140,20 +140,23 @@ public class ChannelDetailsFragment extends LoadingStatePresenterFragment<Channe
             textTitle.setText(channel.title);
         }
 
-        if (courseListAdapter != null)
+        if (courseListAdapter != null) {
             courseListAdapter.setButtonColor(channel.getColorOrDefault());
+        }
     }
 
     @Override
     public void showCourseList(SectionList<String, List<Course>> courses) {
-        if (courseListAdapter != null)
+        if (courseListAdapter != null) {
             courseListAdapter.update(courses);
+        }
 
         if (scrollToCoursePosition >= 0) {
             try {
                 ChannelDetailsActivity activity = ((ChannelDetailsActivity) getActivity());
-                if (activity != null)
+                if (activity != null) {
                     activity.appBarLayout.setExpanded(false);
+                }
 
                 int headerCount = 0;
                 for (int i = 0; i < scrollToCoursePosition; i++) {


### PR DESCRIPTION
Fixes two channel-related bugs:
- "show more courses" sometimes scrolling to wrong course position in channel's course list because of different header counts
- refreshing a channel which previously scrolled to a course, would scroll there again  