### PR TITLE
HLS video

### DIFF
--- a/app/src/main/java/de/xikolo/config/FeatureToggle.java
+++ b/app/src/main/java/de/xikolo/config/FeatureToggle.java
@@ -26,4 +26,8 @@ public class FeatureToggle {
         return BuildConfig.X_FLAVOR == BuildFlavor.OPEN_SAP || BuildConfig.X_FLAVOR == BuildFlavor.OPEN_WHO || BuildConfig.X_FLAVOR == BuildFlavor.MOOC_HOUSE;
     }
 
+    public static boolean hlsVideo() {
+        return Config.DEBUG;
+    }
+
 }

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -30,6 +30,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import de.xikolo.R;
 import de.xikolo.config.Config;
+import de.xikolo.config.FeatureToggle;
 import de.xikolo.managers.DownloadManager;
 import de.xikolo.models.Course;
 import de.xikolo.models.DownloadAsset;
@@ -517,8 +518,10 @@ public class VideoHelper {
             videoMode -> {
                 if (videoMode == VideoSettingsHelper.VideoMode.HD) {
                     return videoDownloadPresent(new DownloadAsset.Course.Item.VideoHD(item, video));
-                } else {
+                } else if (videoMode == VideoSettingsHelper.VideoMode.SD) {
                     return videoDownloadPresent(new DownloadAsset.Course.Item.VideoSD(item, video));
+                } else {
+                    return false;
                 }
             }
         );
@@ -612,7 +615,7 @@ public class VideoHelper {
             videoSettingsHelper.setCurrentQuality(VideoSettingsHelper.VideoMode.HD);
         } else if (videoDownloadPresent(new DownloadAsset.Course.Item.VideoSD(item, video))) { // sd video download available
             videoSettingsHelper.setCurrentQuality(VideoSettingsHelper.VideoMode.SD);
-        } else if (Config.DEBUG && video.singleStream.hlsUrl != null) {
+        } else if (FeatureToggle.hlsVideo() && video.singleStream.hlsUrl != null) {
             videoSettingsHelper.setCurrentQuality(VideoSettingsHelper.VideoMode.AUTO);
         } else if (connectivityStatus == NetworkUtil.TYPE_WIFI || !applicationPreferences.isVideoQualityLimitedOnMobile()) {
             videoSettingsHelper.setCurrentQuality(VideoSettingsHelper.VideoMode.HD);

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -185,13 +185,13 @@ public class VideoHelper {
                         seekBar.setProgress(getCurrentPosition());
                         textCurrentTime.setText(getTimeString(getCurrentPosition()));
                     }
-                });
 
-                if (getCurrentPosition() < getDuration()) {
-                    seekBarPreviewHandler.postDelayed(this, MILLISECONDS);
-                } else {
-                    seekBarUpdaterIsRunning = false;
-                }
+                    if (getCurrentPosition() < getDuration()) {
+                        seekBarPreviewHandler.postDelayed(this, MILLISECONDS);
+                    } else {
+                        seekBarUpdaterIsRunning = false;
+                    }
+                });
             }
         };
 
@@ -449,17 +449,17 @@ public class VideoHelper {
             new VideoSettingsHelper.OnSettingsChangeListener() {
                 @Override
                 public void onSubtitleChanged(@Nullable VideoSubtitles old, @Nullable VideoSubtitles videoSubtitles) {
+                    hideSettings();
                     if (old != videoSubtitles) {
                         saveCurrentPosition();
                         showProgress();
                         updateVideo();
                     }
-
-                    hideSettings();
                 }
 
                 @Override
                 public void onQualityChanged(@NotNull VideoSettingsHelper.VideoMode old, @NotNull VideoSettingsHelper.VideoMode videoMode) {
+                    hideSettings();
                     if (old != videoMode) {
                         String oldSourceString = getSourceString();
 
@@ -477,12 +477,11 @@ public class VideoHelper {
                             oldSourceString,
                             getSourceString());
                     }
-
-                    hideSettings();
                 }
 
                 @Override
                 public void onPlaybackSpeedChanged(@NotNull PlaybackSpeedUtil old, @NotNull PlaybackSpeedUtil speed) {
+                    hideSettings();
                     if (old != speed) {
                         videoView.setPlaybackSpeed(speed.getSpeed());
 
@@ -495,8 +494,6 @@ public class VideoHelper {
                             getCurrentQualityString(),
                             getSourceString());
                     }
-
-                    hideSettings();
                 }
             },
             new VideoSettingsHelper.OnSettingsClickListener() {
@@ -522,89 +519,6 @@ public class VideoHelper {
                     return videoDownloadPresent(new DownloadAsset.Course.Item.VideoSD(item, video));
                 } else {
                     return false;
-                }
-            }
-        );
-
-        this.videoSettingsHelper = new VideoSettingsHelper(
-            activity,
-            video.subtitles,
-            new VideoSettingsHelper.OnSettingsChangeListener() {
-                @Override
-                public void onSubtitleChanged(@Nullable VideoSubtitles old, @Nullable VideoSubtitles videoSubtitles) {
-                    if (old != videoSubtitles) {
-                        saveCurrentPosition();
-                        showProgress();
-                        updateVideo();
-                    }
-
-                    hideSettings();
-                }
-
-                @Override
-                public void onQualityChanged(@NotNull VideoSettingsHelper.VideoMode old, @NotNull VideoSettingsHelper.VideoMode videoMode) {
-                    if (old != videoMode) {
-                        String oldSourceString = getSourceString();
-
-                        saveCurrentPosition();
-                        showProgress();
-                        updateVideo();
-
-                        LanalyticsUtil.trackVideoChangeQuality(item.id,
-                            course.id, module.id,
-                            getCurrentPosition(),
-                            videoSettingsHelper.getCurrentSpeed().getSpeed(),
-                            activity.getResources().getConfiguration().orientation,
-                            getQualityString(old),
-                            getCurrentQualityString(),
-                            oldSourceString,
-                            getSourceString());
-                    }
-
-                    hideSettings();
-                }
-
-                @Override
-                public void onPlaybackSpeedChanged(@NotNull PlaybackSpeedUtil old, @NotNull PlaybackSpeedUtil speed) {
-                    if (old != speed) {
-                        videoView.setPlaybackSpeed(speed.getSpeed());
-
-                        applicationPreferences.setVideoPlaybackSpeed(speed);
-
-                        LanalyticsUtil.trackVideoChangeSpeed(item.id,
-                            course.id, module.id,
-                            getCurrentPosition(),
-                            old.getSpeed(),
-                            speed.getSpeed(),
-                            activity.getResources().getConfiguration().orientation,
-                            getCurrentQualityString(),
-                            getSourceString());
-                    }
-
-                    hideSettings();
-                }
-            },
-            new VideoSettingsHelper.OnSettingsClickListener() {
-                @Override
-                public void onSubtitleClick() {
-                    showSettings(videoSettingsHelper.buildSubtitleView());
-                }
-
-                @Override
-                public void onPlaybackSpeedClick() {
-                    showSettings(videoSettingsHelper.buildPlaybackSpeedView());
-                }
-
-                @Override
-                public void onQualityClick() {
-                    showSettings(videoSettingsHelper.buildQualityView());
-                }
-            },
-            videoMode -> {
-                if (videoMode == VideoSettingsHelper.VideoMode.HD) {
-                    return videoDownloadPresent(new DownloadAsset.Course.Item.VideoHD(item, video));
-                } else {
-                    return videoDownloadPresent(new DownloadAsset.Course.Item.VideoSD(item, video));
                 }
             }
         );
@@ -692,7 +606,7 @@ public class VideoHelper {
 
         videoView.setPlaybackSpeed(videoSettingsHelper.getCurrentSpeed().getSpeed());
 
-        if (videoDownloadPresent(videoAssetDownload)) {
+        if (videoAssetDownload != null && videoDownloadPresent(videoAssetDownload)) {
             videoView.setPreviewUri(Uri.parse("file://" + downloadManager.getDownloadFile(videoAssetDownload)));
         } else if (NetworkUtil.isOnline()) {
             if (video.singleStream.sdUrl != null) {

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -614,7 +614,7 @@ public class VideoHelper {
             videoSettingsHelper.setCurrentQuality(VideoSettingsHelper.VideoMode.SD);
         } else if (Config.DEBUG && video.singleStream.hlsUrl != null) {
             videoSettingsHelper.setCurrentQuality(VideoSettingsHelper.VideoMode.AUTO);
-        } else if (connectivityStatus == NetworkUtil.TYPE_WIFI || !appPreferences.isVideoQualityLimitedOnMobile()) {
+        } else if (connectivityStatus == NetworkUtil.TYPE_WIFI || !applicationPreferences.isVideoQualityLimitedOnMobile()) {
             videoSettingsHelper.setCurrentQuality(VideoSettingsHelper.VideoMode.HD);
         } else {
             videoSettingsHelper.setCurrentQuality(VideoSettingsHelper.VideoMode.SD);
@@ -659,7 +659,7 @@ public class VideoHelper {
                 break;
         }
 
-        if (videoDownloadPresent(videoAssetDownload)) {
+        if (videoAssetDownload != null && videoDownloadPresent(videoAssetDownload)) {
             setLocalVideoUri(videoAssetDownload);
         } else if (NetworkUtil.isOnline()) { // device has internet connection
             if (isHls) {

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -636,18 +636,28 @@ public class VideoHelper {
         viewOfflineHint.setVisibility(View.GONE);
 
         String stream;
-        DownloadAsset.Course.Item videoAssetDownload;
+        DownloadAsset.Course.Item videoAssetDownload = null;
+        boolean isHls = false;
 
-        if (videoSettingsHelper.getCurrentQuality() == VideoSettingsHelper.VideoMode.HD) {
-            stream = video.singleStream.hdUrl;
-            videoAssetDownload = new DownloadAsset.Course.Item.VideoHD(item, video);
-        } else {
-            stream = video.singleStream.sdUrl;
-            videoAssetDownload = new DownloadAsset.Course.Item.VideoSD(item, video);
+        switch (videoSettingsHelper.getCurrentQuality()) {
+            case HD:
+                stream = video.singleStream.hdUrl;
+                videoAssetDownload = new DownloadAsset.Course.Item.VideoHD(item, video);
+                break;
+            case SD:
+                stream = video.singleStream.sdUrl;
+                videoAssetDownload = new DownloadAsset.Course.Item.VideoSD(item, video);
+                break;
+            default: //AUTO
+                stream = video.singleStream.hlsUrl;
+                isHls = true;
+                break;
         }
 
         if (videoDownloadPresent(videoAssetDownload)) {
             setLocalVideoUri(videoAssetDownload);
+        } else if (isHls) {
+            setHlsVideoUri(stream);
         } else if (NetworkUtil.isOnline()) {
             setVideoUri(stream);
         } else if (videoSettingsHelper.getCurrentQuality() == VideoSettingsHelper.VideoMode.HD) {
@@ -691,11 +701,18 @@ public class VideoHelper {
         viewOfflineHint.setVisibility(View.VISIBLE);
     }
 
+    private void setHlsVideoUri(String uri) {
+        if (Config.DEBUG) {
+            Log.i(TAG, "HLS Video HOST_URL: " + uri);
+        }
+        videoView.setVideoURI(Uri.parse(uri), true);
+    }
+
     private void setVideoUri(String uri) {
         if (Config.DEBUG) {
             Log.i(TAG, "Video HOST_URL: " + uri);
         }
-        videoView.setVideoUri(Uri.parse(uri));
+        videoView.setVideoURI(Uri.parse(uri), false);
     }
 
     private void saveCurrentPosition() {

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
@@ -19,8 +19,8 @@ import java.util.*
 
 class VideoSettingsHelper(private val context: Context, private val subtitles: List<VideoSubtitles>?, private val changeListener: OnSettingsChangeListener, private val clickListener: OnSettingsClickListener, private val qualityOfflineInfo: QualityOfflineInfo) {
 
-    enum class VideoMode {
-        SD, HD
+    enum class VideoMode(val title: String) {
+        SD("SD"), HD("HD"), AUTO("Auto")
     }
 
     private val inflater: LayoutInflater = LayoutInflater.from(context)
@@ -35,7 +35,7 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
         list.addView(
             buildSettingsItem(
                 R.string.icon_quality,
-                context.getString(R.string.video_settings_quality) + "  " + context.getString(R.string.video_settings_separator) + "  " + currentQuality.toString() +
+                context.getString(R.string.video_settings_quality) + "  " + context.getString(R.string.video_settings_separator) + "  " + currentQuality.title +
                     if (qualityOfflineInfo.isOfflineAvailable(currentQuality)) " " + context.getString(R.string.video_settings_quality_offline) else "",
                 View.OnClickListener { clickListener.onQualityClick() },
                 false
@@ -72,7 +72,7 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
         list.addView(
             buildSettingsItem(
                 null,
-                VideoMode.HD.toString() +
+                VideoMode.HD.title +
                     if (qualityOfflineInfo.isOfflineAvailable(VideoMode.HD)) " " + context.getString(R.string.video_settings_quality_offline) else "",
                 View.OnClickListener {
                     val oldQuality = currentQuality
@@ -85,7 +85,7 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
         list.addView(
             buildSettingsItem(
                 null,
-                VideoMode.SD.toString() +
+                VideoMode.SD.title +
                     if (qualityOfflineInfo.isOfflineAvailable(VideoMode.SD)) " " + context.getString(R.string.video_settings_quality_offline) else "",
                 View.OnClickListener {
                     val oldQuality = currentQuality

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
@@ -13,6 +13,7 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
 import de.xikolo.R
+import de.xikolo.config.FeatureToggle
 import de.xikolo.models.VideoSubtitles
 import de.xikolo.utils.PlaybackSpeedUtil
 import java.util.*
@@ -69,6 +70,21 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
     fun buildQualityView(): ViewGroup {
         val list = buildSettingsPanel(context.getString(R.string.video_settings_quality))
 
+        if(FeatureToggle.hlsVideo()) {
+            list.addView(
+                buildSettingsItem(
+                    null,
+                    VideoMode.AUTO.title +
+                        if (qualityOfflineInfo.isOfflineAvailable(VideoMode.AUTO)) " " + context.getString(R.string.video_settings_quality_offline) else "",
+                    View.OnClickListener {
+                        val oldQuality = currentQuality
+                        currentQuality = VideoMode.AUTO
+                        changeListener.onQualityChanged(oldQuality, currentQuality)
+                    },
+                    currentQuality == VideoMode.AUTO
+                )
+            )
+        }
         list.addView(
             buildSettingsItem(
                 null,

--- a/app/src/main/java/de/xikolo/views/ExoPlayerVideoView.kt
+++ b/app/src/main/java/de/xikolo/views/ExoPlayerVideoView.kt
@@ -25,7 +25,7 @@ open class ExoPlayerVideoView : PlayerView {
     private lateinit var exoplayer: SimpleExoPlayer
     private lateinit var playerListener: Player.EventListener
     private lateinit var dataSourceFactory: DefaultDataSourceFactory
-    private val bandwidthMeter: DefaultBandwidthMeter = DefaultBandwidthMeter()
+    private lateinit var bandwidthMeter: DefaultBandwidthMeter
 
     private var videoMediaSource: MediaSource? = null
     private var mergedMediaSource: MediaSource? = null
@@ -65,13 +65,15 @@ open class ExoPlayerVideoView : PlayerView {
     private fun setup(context: Context, attrs: AttributeSet?) {
         playerContext = context
 
+        bandwidthMeter = DefaultBandwidthMeter()
         dataSourceFactory = DefaultDataSourceFactory(playerContext, Util.getUserAgent(playerContext, playerContext.packageName), bandwidthMeter)
 
         exoplayer = ExoPlayerFactory.newSimpleInstance(
             context,
             DefaultTrackSelector(
                 AdaptiveTrackSelection.Factory()
-            )
+            ),
+            DefaultLoadControl()
         )
 
         playerListener = object : Player.EventListener {
@@ -144,7 +146,7 @@ open class ExoPlayerVideoView : PlayerView {
 
     fun setVideoURI(uri: Uri, isHls: Boolean) {
         videoMediaSource =
-            if(isHls) {
+            if (isHls) {
                 HlsMediaSource.Factory(dataSourceFactory).createMediaSource(uri)
             } else {
                 ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(uri)

--- a/app/src/main/java/de/xikolo/views/ExoPlayerVideoView.kt
+++ b/app/src/main/java/de/xikolo/views/ExoPlayerVideoView.kt
@@ -9,6 +9,7 @@ import android.util.AttributeSet
 
 import com.google.android.exoplayer2.*
 import com.google.android.exoplayer2.source.*
+import com.google.android.exoplayer2.source.hls.HlsMediaSource
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray
@@ -141,10 +142,13 @@ open class ExoPlayerVideoView : PlayerView {
         )
     }
 
-    fun setVideoUri(uri: Uri) {
-        val dataSourceFactory = DefaultDataSourceFactory(playerContext, Util.getUserAgent(playerContext, playerContext.packageName), bandwidthMeter)
-        videoMediaSource = ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(uri)
-
+    fun setVideoURI(uri: Uri, isHls: Boolean) {
+        videoMediaSource =
+            if(isHls) {
+                HlsMediaSource.Factory(dataSourceFactory).createMediaSource(uri)
+            } else {
+                ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(uri)
+            }
         mergedMediaSource = videoMediaSource
 
         prepare()

--- a/app/src/main/java/de/xikolo/views/ExoPlayerVideoView.kt
+++ b/app/src/main/java/de/xikolo/views/ExoPlayerVideoView.kt
@@ -72,8 +72,7 @@ open class ExoPlayerVideoView : PlayerView {
             context,
             DefaultTrackSelector(
                 AdaptiveTrackSelection.Factory()
-            ),
-            DefaultLoadControl()
+            )
         )
 
         playerListener = object : Player.EventListener {


### PR DESCRIPTION
Adds HLS video stream support to our player.

It is enabled in `Config.DEBUG` through `FeatureToggle.hlsVideo()`.

The video selection logic is now as follows:
HD/SD (offline) -> HLS ("Auto", online) -> HD/SD (online)

![device-2018-11-01-232913](https://user-images.githubusercontent.com/26904189/47883643-12cbad00-de2e-11e8-8b94-0114a18fb7ba.png)

Fixes #79