### PR TITLE
Subtitles downloading and secondary DownloadAssets

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/helper/DownloadViewHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/DownloadViewHelper.kt
@@ -240,9 +240,9 @@ class DownloadViewHelper(
         progressBarDownload.isIndeterminate = true
         progressBarUpdaterRunning = false
 
-        if (downloadAsset.size != 0L) {
+        if (downloadAsset.sizeWithSecondaryAssets != 0L) {
             textFileSize.visibility = View.VISIBLE
-            textFileSize.text = FileUtil.getFormattedFileSize(downloadAsset.size)
+            textFileSize.text = FileUtil.getFormattedFileSize(downloadAsset.sizeWithSecondaryAssets)
         } else {
             textFileSize.visibility = View.GONE
         }
@@ -266,8 +266,8 @@ class DownloadViewHelper(
 
         textFileSize.visibility = View.VISIBLE
 
-        if (downloadAsset.size != 0L) {
-            textFileSize.text = FileUtil.getFormattedFileSize(downloadAsset.size)
+        if (downloadAsset.sizeWithSecondaryAssets != 0L) {
+            textFileSize.text = FileUtil.getFormattedFileSize(downloadAsset.sizeWithSecondaryAssets)
         } else {
             textFileSize.text = FileUtil.getFormattedFileSize(
                 downloadManager.getDownloadFile(downloadAsset)

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -533,7 +533,12 @@ public class VideoHelper {
 
         VideoSubtitles currentSubtitles = videoSettingsHelper.getCurrentVideoSubtitles();
         if (currentSubtitles != null) {
-            videoView.showSubtitles(currentSubtitles.vttUrl, currentSubtitles.language);
+            DownloadAsset.Course.Item.Subtitles downloadAsset = new DownloadAsset.Course.Item.Subtitles(currentSubtitles, item);
+            if (downloadManager.downloadExists(downloadAsset)) {
+                videoView.showSubtitles("file://" + downloadManager.getDownloadFile(downloadAsset).getAbsolutePath(), currentSubtitles.language);
+            } else {
+                videoView.showSubtitles(currentSubtitles.vttUrl, currentSubtitles.language);
+            }
             applicationPreferences.setVideoSubtitlesLanguage(currentSubtitles.language);
         } else {
             videoView.removeSubtitles();

--- a/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
@@ -13,7 +13,6 @@ import de.xikolo.config.GlideApp
 import de.xikolo.controllers.base.LoadingStatePresenterFragment
 import de.xikolo.controllers.helper.DownloadViewHelper
 import de.xikolo.controllers.video.VideoActivityAutoBundle
-import de.xikolo.managers.DownloadManager
 import de.xikolo.models.*
 import de.xikolo.presenters.base.PresenterFactory
 import de.xikolo.presenters.section.VideoPreviewPresenter
@@ -116,17 +115,6 @@ class VideoPreviewFragment : LoadingStatePresenterFragment<VideoPreviewPresenter
                     DownloadAsset.Course.Item.VideoHD(item, video),
                     activity.getText(R.string.video_hd_as_mp4)
                 )
-                video.subtitles?.forEach {
-                    dvh.addSecondaryDownload(
-                        DownloadAsset.Course.Item.Subtitles(it, item)
-                    )
-                }
-                dvh.secondaryDownloadListener = object : DownloadViewHelper.SecondaryDownloadListener {
-                    override fun onDelete(downloadAsset: DownloadAsset, downloadManager: DownloadManager): Boolean {
-                        return !downloadManager.downloadExists(DownloadAsset.Course.Item.VideoHD(item, video))
-                            && !downloadManager.downloadExists(DownloadAsset.Course.Item.VideoSD(item, video))
-                    }
-                }
                 dvh.onOpenFileClick(R.string.play) { presenter.onPlayClicked() }
                 linearLayoutDownloads.addView(dvh.view)
                 downloadViewHelpers.add(dvh)
@@ -138,17 +126,6 @@ class VideoPreviewFragment : LoadingStatePresenterFragment<VideoPreviewPresenter
                     DownloadAsset.Course.Item.VideoSD(item, video),
                     activity.getText(R.string.video_sd_as_mp4)
                 )
-                video.subtitles?.forEach {
-                    dvh.addSecondaryDownload(
-                        DownloadAsset.Course.Item.Subtitles(it, item)
-                    )
-                }
-                dvh.secondaryDownloadListener = object : DownloadViewHelper.SecondaryDownloadListener {
-                    override fun onDelete(downloadAsset: DownloadAsset, downloadManager: DownloadManager): Boolean {
-                        return !downloadManager.downloadExists(DownloadAsset.Course.Item.VideoHD(item, video))
-                            && !downloadManager.downloadExists(DownloadAsset.Course.Item.VideoSD(item, video))
-                    }
-                }
                 dvh.onOpenFileClick(R.string.play) { presenter.onPlayClicked() }
                 linearLayoutDownloads.addView(dvh.view)
                 downloadViewHelpers.add(dvh)

--- a/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
@@ -13,6 +13,7 @@ import de.xikolo.config.GlideApp
 import de.xikolo.controllers.base.LoadingStatePresenterFragment
 import de.xikolo.controllers.helper.DownloadViewHelper
 import de.xikolo.controllers.video.VideoActivityAutoBundle
+import de.xikolo.managers.DownloadManager
 import de.xikolo.models.*
 import de.xikolo.presenters.base.PresenterFactory
 import de.xikolo.presenters.section.VideoPreviewPresenter
@@ -115,6 +116,17 @@ class VideoPreviewFragment : LoadingStatePresenterFragment<VideoPreviewPresenter
                     DownloadAsset.Course.Item.VideoHD(item, video),
                     activity.getText(R.string.video_hd_as_mp4)
                 )
+                video.subtitles?.forEach {
+                    dvh.addSecondaryDownload(
+                        DownloadAsset.Course.Item.Subtitles(it, item)
+                    )
+                }
+                dvh.secondaryDownloadListener = object : DownloadViewHelper.SecondaryDownloadListener {
+                    override fun onDelete(downloadAsset: DownloadAsset, downloadManager: DownloadManager): Boolean {
+                        return !downloadManager.downloadExists(DownloadAsset.Course.Item.VideoHD(item, video))
+                            && !downloadManager.downloadExists(DownloadAsset.Course.Item.VideoSD(item, video))
+                    }
+                }
                 dvh.onOpenFileClick(R.string.play) { presenter.onPlayClicked() }
                 linearLayoutDownloads.addView(dvh.view)
                 downloadViewHelpers.add(dvh)
@@ -126,6 +138,17 @@ class VideoPreviewFragment : LoadingStatePresenterFragment<VideoPreviewPresenter
                     DownloadAsset.Course.Item.VideoSD(item, video),
                     activity.getText(R.string.video_sd_as_mp4)
                 )
+                video.subtitles?.forEach {
+                    dvh.addSecondaryDownload(
+                        DownloadAsset.Course.Item.Subtitles(it, item)
+                    )
+                }
+                dvh.secondaryDownloadListener = object : DownloadViewHelper.SecondaryDownloadListener {
+                    override fun onDelete(downloadAsset: DownloadAsset, downloadManager: DownloadManager): Boolean {
+                        return !downloadManager.downloadExists(DownloadAsset.Course.Item.VideoHD(item, video))
+                            && !downloadManager.downloadExists(DownloadAsset.Course.Item.VideoSD(item, video))
+                    }
+                }
                 dvh.onOpenFileClick(R.string.play) { presenter.onPlayClicked() }
                 linearLayoutDownloads.addView(dvh.view)
                 downloadViewHelpers.add(dvh)

--- a/app/src/main/java/de/xikolo/managers/DownloadManager.kt
+++ b/app/src/main/java/de/xikolo/managers/DownloadManager.kt
@@ -63,6 +63,7 @@ class DownloadManager(activity: FragmentActivity) {
                         bundle.putString(DownloadService.ARG_TITLE, downloadAsset.title)
                         bundle.putString(DownloadService.ARG_URL, downloadAsset.url)
                         bundle.putString(DownloadService.ARG_FILE_PATH, downloadAsset.filePath)
+                        bundle.putBoolean(DownloadService.ARG_SHOW_NOTIFICATION, downloadAsset.showNotification)
 
                         intent.putExtras(bundle)
                         context.startService(intent)

--- a/app/src/main/java/de/xikolo/managers/DownloadManager.kt
+++ b/app/src/main/java/de/xikolo/managers/DownloadManager.kt
@@ -103,7 +103,7 @@ class DownloadManager(activity: FragmentActivity) {
                 } else {
                     EventBus.getDefault().post(DownloadDeletedEvent(downloadAsset))
 
-                    if (getDownloadFile(downloadAsset)!!.delete()) {
+                    if (getDownloadFile(downloadAsset)?.delete() == true) {
                         if (deleteSecondaryDownloads) {
                             downloadAsset.secondaryAssets.forEach {
                                 if (downloadAsset.deleteSecondaryAssets(it, this)) {
@@ -192,16 +192,20 @@ class DownloadManager(activity: FragmentActivity) {
         var totalBytes = 0L
         val mainDownload = DownloadService.getInstance()?.getDownload(downloadAsset.url)
         totalBytes +=
-            if (mainDownload != null && mainDownload.totalBytes > 0L)
+            if (mainDownload != null && mainDownload.totalBytes > 0L) {
                 mainDownload.totalBytes
-            else downloadAsset.size
+            } else {
+                downloadAsset.size
+            }
 
         downloadAsset.secondaryAssets.forEach {
             val secondaryDownload = DownloadService.getInstance()?.getDownload(it.url)
             totalBytes +=
-                if (secondaryDownload != null && secondaryDownload.totalBytes > 0L)
+                if (secondaryDownload != null && secondaryDownload.totalBytes > 0L) {
                     secondaryDownload.totalBytes
-                else it.size
+                } else {
+                    it.size
+                }
         }
 
         return totalBytes

--- a/app/src/main/java/de/xikolo/managers/DownloadManager.kt
+++ b/app/src/main/java/de/xikolo/managers/DownloadManager.kt
@@ -98,11 +98,11 @@ class DownloadManager(activity: FragmentActivity) {
                 if (Config.DEBUG) Log.d(TAG, "Delete download " + downloadAsset.filePath)
 
                 if (!downloadExists(downloadAsset)) {
-                    StorageUtil.cleanStorage(File(downloadAsset.filePath))
+                    StorageUtil.cleanStorage(File(downloadAsset.filePath).parentFile)
                     false
                 } else {
                     EventBus.getDefault().post(DownloadDeletedEvent(downloadAsset))
-                    return File(downloadAsset.filePath).delete()
+                    return getDownloadFile(downloadAsset)!!.delete()
                 }
             } else {
                 pendingAction = PendingAction(ActionType.DELETE, downloadAsset)
@@ -206,6 +206,7 @@ class DownloadManager(activity: FragmentActivity) {
             }
         }
 
+        downloadAsset.storage = originalStorage
         return null
     }
 

--- a/app/src/main/java/de/xikolo/managers/DownloadManager.kt
+++ b/app/src/main/java/de/xikolo/managers/DownloadManager.kt
@@ -194,14 +194,14 @@ class DownloadManager(activity: FragmentActivity) {
         totalBytes +=
             if (mainDownload != null && mainDownload.totalBytes > 0L)
                 mainDownload.totalBytes
-            else downloadAsset.singleSize
+            else downloadAsset.size
 
         downloadAsset.secondaryAssets.forEach {
             val secondaryDownload = DownloadService.getInstance()?.getDownload(it.url)
             totalBytes +=
                 if (secondaryDownload != null && secondaryDownload.totalBytes > 0L)
                     secondaryDownload.totalBytes
-                else it.singleSize
+                else it.size
         }
 
         return totalBytes

--- a/app/src/main/java/de/xikolo/models/Download.java
+++ b/app/src/main/java/de/xikolo/models/Download.java
@@ -10,6 +10,8 @@ public class Download {
 
     public String filePath;
 
+    public boolean showNotification;
+
     public long totalBytes;
 
     public long bytesWritten;

--- a/app/src/main/java/de/xikolo/models/DownloadAsset.kt
+++ b/app/src/main/java/de/xikolo/models/DownloadAsset.kt
@@ -15,7 +15,16 @@ sealed class DownloadAsset(val url: String?, open val fileName: String, var stor
     open val title: String
         get() = fileName
 
-    open val size: Long = 0L
+    open val singleSize: Long = 0L
+
+    val size: Long
+        get() {
+            var secondarySize = 0L
+            secondaryAssets.forEach {
+                secondarySize += it.size
+            }
+            return singleSize + secondarySize
+        }
 
     val filePath: String
         get() = fileFolder + File.separator + fileName
@@ -70,30 +79,30 @@ sealed class DownloadAsset(val url: String?, open val fileName: String, var stor
 
             class Slides(item: de.xikolo.models.Item, video: Video) : Item(video.slidesUrl, "slides_${item.id}.pdf", item) {
                 override val title = "Slides: " + item.title
-                override val size = video.slidesSize.toLong()
+                override val singleSize = video.slidesSize.toLong()
             }
 
             class Transcript(item: de.xikolo.models.Item, video: Video) : Item(video.transcriptUrl, "transcript_${item.id}.pdf", item) {
                 override val title = "Transcript: " + item.title
-                override val size = video.transcriptSize.toLong()
+                override val singleSize = video.transcriptSize.toLong()
             }
 
             class VideoSD(item: de.xikolo.models.Item, video: Video) : Item(video.singleStream.sdUrl, "video_sd_${item.id}.mp4", item) {
                 override val title = "Video (SD): " + item.title
                 override val mimeType = "video/mp4"
-                override val size = video.singleStream.sdSize.toLong()
+                override val singleSize = video.singleStream.sdSize.toLong()
             }
 
             class VideoHD(item: de.xikolo.models.Item, video: Video) : Item(video.singleStream.hdUrl, "video_hd_${item.id}.mp4", item) {
                 override val title = "Video (HD): " + item.title
                 override val mimeType = "video/mp4"
-                override val size = video.singleStream.hdSize.toLong()
+                override val singleSize = video.singleStream.hdSize.toLong()
             }
 
             class Audio(item: de.xikolo.models.Item, video: Video) : Item(video.audioUrl, "audio_${item.id}.mp3", item) {
                 override val title = "Audio: " + item.title
                 override val mimeType = "audio/mpeg"
-                override val size = video.audioSize.toLong()
+                override val singleSize = video.audioSize.toLong()
             }
 
             class Subtitles(videoSubtitles: VideoSubtitles, item: de.xikolo.models.Item) : Item(videoSubtitles.vttUrl, "subtitles_${videoSubtitles.language}_${item.id}.vtt", item) {

--- a/app/src/main/java/de/xikolo/models/DownloadAsset.kt
+++ b/app/src/main/java/de/xikolo/models/DownloadAsset.kt
@@ -2,7 +2,6 @@ package de.xikolo.models
 
 import de.xikolo.App
 import de.xikolo.R
-import de.xikolo.services.DownloadService
 import de.xikolo.utils.FileUtil
 import de.xikolo.utils.StorageUtil
 import java.io.File
@@ -22,6 +21,8 @@ sealed class DownloadAsset(val url: String?, open val fileName: String, var stor
         get() = fileFolder + File.separator + fileName
 
     open val mimeType = "application/pdf"
+
+    open val showNotification = true
 
     class Document(
         val document: de.xikolo.models.Document,
@@ -97,7 +98,7 @@ sealed class DownloadAsset(val url: String?, open val fileName: String, var stor
                 override val fileFolder
                     get() = super.fileFolder + File.separator + "Subtitles"
 
-                override val title = DownloadService.NO_NOTIFICATION
+                override val showNotification = false
                 override val mimeType = "text/vtt"
             }
         }

--- a/app/src/main/java/de/xikolo/models/DownloadAsset.kt
+++ b/app/src/main/java/de/xikolo/models/DownloadAsset.kt
@@ -24,6 +24,8 @@ sealed class DownloadAsset(val url: String?, open val fileName: String, var stor
 
     open val showNotification = true
 
+    open val secondaryAssets = mutableSetOf<DownloadAsset>()
+
     class Document(
         val document: de.xikolo.models.Document,
         documentLocalization: DocumentLocalization

--- a/app/src/main/java/de/xikolo/models/DownloadAsset.kt
+++ b/app/src/main/java/de/xikolo/models/DownloadAsset.kt
@@ -2,11 +2,11 @@ package de.xikolo.models
 
 import de.xikolo.App
 import de.xikolo.R
+import de.xikolo.services.DownloadService
 import de.xikolo.utils.FileUtil
 import de.xikolo.utils.StorageUtil
 import java.io.File
 
-// the file path should identify a download uniquely, thus this DownloadAsset object can be used as an identifier for downloads
 sealed class DownloadAsset(val url: String?, open val fileName: String, var storage: File = StorageUtil.getStorage(App.getInstance())) {
 
     // must not end with separator and always have a getter function, otherwise dynamic storage changes will not work
@@ -58,39 +58,47 @@ sealed class DownloadAsset(val url: String?, open val fileName: String, var stor
         override val fileFolder
             get() = super.fileFolder + File.separator + "Courses" + File.separator + FileUtil.escapeFilename(course.title) + "_" + course.id
 
-        sealed class Item(url: String?, fileName: String, val item: de.xikolo.models.Item, val video: Video) : Course(url, fileName, item.section.course) {
+        sealed class Item(url: String?, fileName: String, val item: de.xikolo.models.Item) : Course(url, fileName, item.section.course) {
 
             override val fileFolder
                 get() = super.fileFolder + File.separator + FileUtil.escapeFilename(item.section.title) + "_" + item.section.id
 
             override val fileName = FileUtil.escapeFilename(item.title) + "_" + fileName
 
-            class Slides(item: de.xikolo.models.Item, video: Video) : Item(video.slidesUrl, "slides_${item.id}.pdf", item, video) {
+            class Slides(item: de.xikolo.models.Item, video: Video) : Item(video.slidesUrl, "slides_${item.id}.pdf", item) {
                 override val title = "Slides: " + item.title
                 override val size = video.slidesSize.toLong()
             }
 
-            class Transcript(item: de.xikolo.models.Item, video: Video) : Item(video.transcriptUrl, "transcript_${item.id}.pdf", item, video) {
+            class Transcript(item: de.xikolo.models.Item, video: Video) : Item(video.transcriptUrl, "transcript_${item.id}.pdf", item) {
                 override val title = "Transcript: " + item.title
                 override val size = video.transcriptSize.toLong()
             }
 
-            class VideoSD(item: de.xikolo.models.Item, video: Video) : Item(video.singleStream.sdUrl, "video_sd_${item.id}.mp4", item, video) {
+            class VideoSD(item: de.xikolo.models.Item, video: Video) : Item(video.singleStream.sdUrl, "video_sd_${item.id}.mp4", item) {
                 override val title = "Video (SD): " + item.title
                 override val mimeType = "video/mp4"
                 override val size = video.singleStream.sdSize.toLong()
             }
 
-            class VideoHD(item: de.xikolo.models.Item, video: Video) : Item(video.singleStream.hdUrl, "video_hd_${item.id}.mp4", item, video) {
+            class VideoHD(item: de.xikolo.models.Item, video: Video) : Item(video.singleStream.hdUrl, "video_hd_${item.id}.mp4", item) {
                 override val title = "Video (HD): " + item.title
                 override val mimeType = "video/mp4"
                 override val size = video.singleStream.hdSize.toLong()
             }
 
-            class Audio(item: de.xikolo.models.Item, video: Video) : Item(video.audioUrl, "audio_${item.id}.mp3", item, video) {
+            class Audio(item: de.xikolo.models.Item, video: Video) : Item(video.audioUrl, "audio_${item.id}.mp3", item) {
                 override val title = "Audio: " + item.title
                 override val mimeType = "audio/mpeg"
-                override val size = video.transcriptSize.toLong()
+                override val size = video.audioSize.toLong()
+            }
+
+            class Subtitles(videoSubtitles: VideoSubtitles, item: de.xikolo.models.Item) : Item(videoSubtitles.vttUrl, "subtitles_${videoSubtitles.language}_${item.id}.vtt", item) {
+                override val fileFolder
+                    get() = super.fileFolder + File.separator + "Subtitles"
+
+                override val title = DownloadService.NO_NOTIFICATION
+                override val mimeType = "text/vtt"
             }
         }
     }

--- a/app/src/main/java/de/xikolo/models/DownloadAsset.kt
+++ b/app/src/main/java/de/xikolo/models/DownloadAsset.kt
@@ -16,15 +16,15 @@ sealed class DownloadAsset(val url: String?, open val fileName: String, var stor
     open val title: String
         get() = fileName
 
-    open val singleSize: Long = 0L
+    open val size: Long = 0L
 
-    val size: Long
+    val sizeWithSecondaryAssets: Long
         get() {
             var secondarySize = 0L
             secondaryAssets.forEach {
-                secondarySize += it.size
+                secondarySize += it.sizeWithSecondaryAssets
             }
-            return singleSize + secondarySize
+            return size + secondarySize
         }
 
     val filePath: String
@@ -82,18 +82,18 @@ sealed class DownloadAsset(val url: String?, open val fileName: String, var stor
 
             class Slides(item: de.xikolo.models.Item, video: Video) : Item(video.slidesUrl, "slides_${item.id}.pdf", item) {
                 override val title = "Slides: " + item.title
-                override val singleSize = video.slidesSize.toLong()
+                override val size = video.slidesSize.toLong()
             }
 
             class Transcript(item: de.xikolo.models.Item, video: Video) : Item(video.transcriptUrl, "transcript_${item.id}.pdf", item) {
                 override val title = "Transcript: " + item.title
-                override val singleSize = video.transcriptSize.toLong()
+                override val size = video.transcriptSize.toLong()
             }
 
             class VideoSD(item: de.xikolo.models.Item, val video: Video) : Item(video.singleStream.sdUrl, "video_sd_${item.id}.mp4", item) {
                 override val title = "Video (SD): " + item.title
                 override val mimeType = "video/mp4"
-                override val singleSize = video.singleStream.sdSize.toLong()
+                override val size = video.singleStream.sdSize.toLong()
 
                 override val secondaryAssets: MutableSet<DownloadAsset>
                     get() {
@@ -111,7 +111,7 @@ sealed class DownloadAsset(val url: String?, open val fileName: String, var stor
             class VideoHD(item: de.xikolo.models.Item, val video: Video) : Item(video.singleStream.hdUrl, "video_hd_${item.id}.mp4", item) {
                 override val title = "Video (HD): " + item.title
                 override val mimeType = "video/mp4"
-                override val singleSize = video.singleStream.hdSize.toLong()
+                override val size = video.singleStream.hdSize.toLong()
 
                 override val secondaryAssets: MutableSet<DownloadAsset>
                     get() {
@@ -129,7 +129,7 @@ sealed class DownloadAsset(val url: String?, open val fileName: String, var stor
             class Audio(item: de.xikolo.models.Item, video: Video) : Item(video.audioUrl, "audio_${item.id}.mp3", item) {
                 override val title = "Audio: " + item.title
                 override val mimeType = "audio/mpeg"
-                override val singleSize = video.audioSize.toLong()
+                override val size = video.audioSize.toLong()
             }
 
             class Subtitles(videoSubtitles: VideoSubtitles, item: de.xikolo.models.Item) : Item(videoSubtitles.vttUrl, "subtitles_${videoSubtitles.language}_${item.id}.vtt", item) {

--- a/app/src/main/java/de/xikolo/services/DownloadService.java
+++ b/app/src/main/java/de/xikolo/services/DownloadService.java
@@ -37,13 +37,13 @@ public class DownloadService extends Service {
 
     public static final String TAG = DownloadService.class.getSimpleName();
 
-    public static final String NO_NOTIFICATION = "DownloadService/NO_NOTIFICATION";
-
     public static final String ARG_TITLE = "title";
 
     public static final String ARG_URL = "url";
 
     public static final String ARG_FILE_PATH = "file_path";
+
+    public static final String ARG_SHOW_NOTIFICATION = "show_notification";
 
     private ServiceHandler serviceHandler;
 
@@ -101,7 +101,7 @@ public class DownloadService extends Service {
 
         if (intent != null && intent.getExtras() != null && intent.getExtras().getString(ARG_TITLE) != null) {
             String title = intent.getExtras().getString(ARG_TITLE);
-            if (!title.equals(NO_NOTIFICATION)) {
+            if (intent.getExtras().getBoolean(ARG_SHOW_NOTIFICATION, true)) {
                 List<String> titles = getRunningDownloadTitles();
                 titles.add(title);
 
@@ -191,7 +191,7 @@ public class DownloadService extends Service {
         List<String> titles = new ArrayList<>();
 
         for (Download download : downloadMap.values()) {
-            if (isDownloading(download.url) && !download.title.equals(NO_NOTIFICATION)) {
+            if (isDownloading(download.url) && download.showNotification) {
                 titles.add(download.title);
             }
         }
@@ -232,7 +232,7 @@ public class DownloadService extends Service {
 
         if (download != null) {
             download.state = Download.State.SUCCESSFUL;
-            if(!download.title.equals(NO_NOTIFICATION)) {
+            if(download.showNotification) {
                 notificationUtil.showDownloadCompletedNotification(download);
             }
             EventBus.getDefault().post(new DownloadCompletedEvent(download.url));
@@ -259,6 +259,7 @@ public class DownloadService extends Service {
             final String title = message.getData().getString(ARG_TITLE);
             final String url = message.getData().getString(ARG_URL);
             final String filePath = message.getData().getString(ARG_FILE_PATH);
+            final boolean showNotification = message.getData().getBoolean(ARG_SHOW_NOTIFICATION);
 
             int allowedNetworkTypes = DownloadRequest.NETWORK_WIFI | DownloadRequest.NETWORK_MOBILE;
             ApplicationPreferences appPreferences = new ApplicationPreferences();
@@ -309,6 +310,7 @@ public class DownloadService extends Service {
             download.title = title;
             download.url = url;
             download.filePath = filePath;
+            download.showNotification = showNotification;
             download.id = downloadClient.add(request);
 
             downloadMap.putIfAbsent(download.id, download);

--- a/app/src/main/java/de/xikolo/utils/LanalyticsUtil.kt
+++ b/app/src/main/java/de/xikolo/utils/LanalyticsUtil.kt
@@ -140,10 +140,11 @@ object LanalyticsUtil {
             is DownloadAsset.Course.Item.Slides        -> "DOWNLOADED_SLIDES"
             is DownloadAsset.Course.Item.Transcript    -> "DOWNLOADED_TRANSCRIPT"
             is DownloadAsset.Course.Item.Audio         -> "DOWNLOADED_AUDIO"
+            is DownloadAsset.Course.Item.Subtitles     -> "DOWNLOADED_SUBTITLES"
         }
 
         createEventBuilder()
-            .setResource(itemDownloadAsset.video.id, "video")
+            .setResource(itemDownloadAsset.item.id, "video")
             .setVerb(verb)
             .putContext(CONTEXT_COURSE_ID, itemDownloadAsset.course.id)
             .putContext(CONTEXT_SECTION_ID, itemDownloadAsset.item.section.id)

--- a/app/src/main/java/de/xikolo/utils/StorageUtil.kt
+++ b/app/src/main/java/de/xikolo/utils/StorageUtil.kt
@@ -116,7 +116,7 @@ object StorageUtil {
                 file.delete()
             }
         } else {
-            if ((file.extension.endsWith("tmp") && (DownloadService.getInstance() == null || !DownloadService.getInstance().isDownloading))
+            if ((file.extension.endsWith("tmp") && (DownloadService.getInstance() == null || !DownloadService.getInstance().isDownloadingTempFile(file)))
                 || file.name.endsWith("slides.pdf")
                 || file.name.endsWith("transcript.pdf")
                 || file.name.endsWith("video_hd.mp4")


### PR DESCRIPTION
Adds the option for secondary DownloadAssets in the `DownloadAsset` model and applies the new option for `Subtitles`. 

Major changes:
- secondary DownloadAsset handling is implemented on the `DownloadManager` layer
- adjusted `DownloadViewHelper` and `DownloadManager` to support it
- removed `getDownload(DownloadAsset)` method in `DownloadManager` which was accessed by `DownloadViewHelper` to provide updates on download status and replaced it with `getDownloadWrittenBytes(DownloadAsset)` and `getDownloadTotalBytes(DownloadAsset)`
- added `ARG_SHOW_NOTIFICATION` bundle field for `DownloadService` option to decide whether to show a download notification for a specific `DownloadAsset` (can be set in `DownloadAsset.showNotification`)
- `VideoHelper` uses downloaded subtitles if available
- secondary subtitle download assets are added to `VideoHD` and `VideoSD` models and are only deleted when neither HD or SD are downloaded