### PR TITLE
Picture-In-Picture for Videos

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -176,7 +176,7 @@
             android:resizeableActivity="true"
             android:supportsPictureInPicture="true"
             android:excludeFromRecents="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:parentActivityName=".controllers.section.CourseItemsActivity"
             android:theme="@style/AppThemeDarkStatusBar">
             <meta-data

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -172,7 +172,10 @@
         </activity>
         <activity
             android:name=".controllers.video.VideoActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
+            android:resizeableActivity="true"
+            android:supportsPictureInPicture="true"
+            android:excludeFromRecents="true"
             android:launchMode="singleTop"
             android:parentActivityName=".controllers.section.CourseItemsActivity"
             android:theme="@style/AppThemeDarkStatusBar">

--- a/app/src/main/java/de/xikolo/config/FeatureToggle.java
+++ b/app/src/main/java/de/xikolo/config/FeatureToggle.java
@@ -1,5 +1,9 @@
 package de.xikolo.config;
 
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
 import de.xikolo.BuildConfig;
 
 public class FeatureToggle {
@@ -30,4 +34,7 @@ public class FeatureToggle {
         return Config.DEBUG;
     }
 
+    public static boolean pictureInPicture(Context context) {
+        return Build.VERSION.SDK_INT >= 26 && context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE);
+    }
 }

--- a/app/src/main/java/de/xikolo/controllers/base/BaseActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/base/BaseActivity.java
@@ -137,6 +137,9 @@ public abstract class BaseActivity extends AppCompatActivity implements CastStat
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
 
+        setIntent(intent);
+        AutoBundle.bind(this);
+
         handleIntent(intent);
     }
 

--- a/app/src/main/java/de/xikolo/controllers/base/BasePresenterActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/base/BasePresenterActivity.java
@@ -1,6 +1,7 @@
 package de.xikolo.controllers.base;
 
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.LoaderManager;
@@ -33,6 +34,14 @@ public abstract class BasePresenterActivity<P extends Presenter<V>, V extends Vi
             this.presenter = ((PresenterLoader<P>) loader).getPresenter();
             onPresenterCreatedOrRestored(presenter);
         }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        getSupportLoaderManager().destroyLoader(loaderId());
+        initLoader();
     }
 
     private void initLoader() {

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -538,10 +538,10 @@ public class VideoHelper {
                 }
 
                 @Override
-                public void onPiPClick() {
+                public void onPipClick() {
                     hideSettings();
                     if(controllerListener != null) {
-                        controllerListener.onPiPClick();
+                        controllerListener.onPipClick();
                     }
                 }
             },
@@ -737,7 +737,7 @@ public class VideoHelper {
 
         void onSettingsClosed();
 
-        void onPiPClick();
+        void onPipClick();
     }
 
     private static class MessageHandler extends Handler {

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -354,6 +354,13 @@ public class VideoHelper {
         return (int) videoView.getDuration();
     }
 
+    public boolean isPlaying() {
+        if (videoView != null) {
+            return videoView.isPlaying();
+        }
+        return false;
+    }
+
     public void play() {
         buttonPlay.setText(activity.getString(R.string.icon_pause));
         videoView.start();

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -375,7 +375,7 @@ public class VideoHelper {
         saveCurrentPosition();
     }
 
-    private void release() {
+    public void release() {
         pause();
         videoView.release();
         seekBarPreviewThread.quit();

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -459,7 +459,6 @@ public class VideoHelper {
             hideSettings();
             return false;
         }
-        release();
         return true;
     }
 

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -536,6 +536,14 @@ public class VideoHelper {
                 public void onQualityClick() {
                     showSettings(videoSettingsHelper.buildQualityView());
                 }
+
+                @Override
+                public void onPiPClick() {
+                    hideSettings();
+                    if(controllerListener != null) {
+                        controllerListener.onPiPClick();
+                    }
+                }
             },
             videoMode -> {
                 if (videoMode == VideoSettingsHelper.VideoMode.HD) {
@@ -728,6 +736,8 @@ public class VideoHelper {
         void onSettingsOpen();
 
         void onSettingsClosed();
+
+        void onPiPClick();
     }
 
     private static class MessageHandler extends Handler {

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
@@ -13,6 +13,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import de.xikolo.R
 import de.xikolo.config.FeatureToggle
+import de.xikolo.managers.PermissionManager
 import de.xikolo.models.VideoSubtitles
 import de.xikolo.utils.DisplayUtil
 import de.xikolo.utils.PlaybackSpeedUtil
@@ -63,7 +64,7 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
                 )
             )
         }
-        if(DisplayUtil.supportsPictureInPicture(context)) {
+        if(DisplayUtil.supportsPictureInPicture(context) && PermissionManager.hasPiPPermission(context)) {
             list.addView(
                 buildSettingsItem(
                     R.string.icon_pip,

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
@@ -15,7 +15,6 @@ import de.xikolo.R
 import de.xikolo.config.FeatureToggle
 import de.xikolo.managers.PermissionManager
 import de.xikolo.models.VideoSubtitles
-import de.xikolo.utils.DisplayUtil
 import de.xikolo.utils.PlaybackSpeedUtil
 import java.util.*
 
@@ -64,12 +63,12 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
                 )
             )
         }
-        if(DisplayUtil.supportsPictureInPicture(context) && PermissionManager.hasPiPPermission(context)) {
+        if(FeatureToggle.pictureInPicture(context) && PermissionManager.hasPipPermission(context)) {
             list.addView(
                 buildSettingsItem(
                     R.string.icon_pip,
                     context.getString(R.string.video_settings_pip),
-                    View.OnClickListener { clickListener.onPiPClick() },
+                    View.OnClickListener { clickListener.onPipClick() },
                     false
                 )
             )
@@ -246,7 +245,7 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
 
         fun onSubtitleClick()
 
-        fun onPiPClick()
+        fun onPipClick()
     }
 
     // also invoked when old value equal to new value

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
@@ -3,7 +3,6 @@ package de.xikolo.controllers.helper
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.provider.Settings
 import android.support.annotation.StringRes
 import android.support.v4.content.ContextCompat
@@ -15,6 +14,7 @@ import android.widget.TextView
 import de.xikolo.R
 import de.xikolo.config.FeatureToggle
 import de.xikolo.models.VideoSubtitles
+import de.xikolo.utils.DisplayUtil
 import de.xikolo.utils.PlaybackSpeedUtil
 import java.util.*
 
@@ -59,6 +59,16 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
                     else
                         "",
                     View.OnClickListener { clickListener.onSubtitleClick() },
+                    false
+                )
+            )
+        }
+        if(DisplayUtil.supportsPictureInPicture(context)) {
+            list.addView(
+                buildSettingsItem(
+                    R.string.icon_pip,
+                    context.getString(R.string.video_settings_pip),
+                    View.OnClickListener { clickListener.onPiPClick() },
                     false
                 )
             )
@@ -141,12 +151,7 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
             context.getString(R.string.video_settings_subtitles),
             context.getString(R.string.icon_settings),
             View.OnClickListener {
-                val subtitleSettings =
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
-                        Settings.ACTION_CAPTIONING_SETTINGS
-                    else
-                        Settings.ACTION_ACCESSIBILITY_SETTINGS
-                ContextCompat.startActivity(context, Intent(subtitleSettings), null)
+                ContextCompat.startActivity(context, Intent(Settings.ACTION_CAPTIONING_SETTINGS), null)
             }
         )
 
@@ -239,6 +244,8 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
         fun onPlaybackSpeedClick()
 
         fun onSubtitleClick()
+
+        fun onPiPClick()
     }
 
     // also invoked when old value equal to new value

--- a/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
@@ -161,7 +161,7 @@ class VideoPreviewFragment : LoadingStatePresenterFragment<VideoPreviewPresenter
 
     override fun startVideo(video: Video) {
         activity?.let {
-            val intent = VideoActivityAutoBundle.builder(courseId, sectionId, itemId, video.id).build(it)
+            val intent = VideoActivityAutoBundle.builder(courseId, sectionId, itemId, video.id).parentIntent(it.intent).build(it)
             startActivity(intent)
         }
     }

--- a/app/src/main/java/de/xikolo/controllers/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/settings/SettingsFragment.kt
@@ -236,9 +236,9 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         }
     }
 
-    private fun refreshPipStatus(){
+    private fun refreshPipStatus() {
         val pipSettings = findPreference(getString(R.string.preference_video_pip))
-        if(!PermissionManager.hasPipPermission(context)){
+        if (!PermissionManager.hasPipPermission(context)) {
             pipSettings.summary = getString(R.string.settings_summary_video_pip_unavailable)
         } else {
             pipSettings.summary = ""

--- a/app/src/main/java/de/xikolo/controllers/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/settings/SettingsFragment.kt
@@ -47,6 +47,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
     override fun onResume() {
         preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+        refreshPiPStatus()
         super.onResume()
     }
 
@@ -159,6 +160,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
                 }
                 true
             }
+            refreshPiPStatus()
         }
 
         val copyright = findPreference(getString(R.string.preference_copyright))
@@ -227,6 +229,15 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             buildLogoutView(loginOut)
         } else {
             buildLoginView(loginOut)
+        }
+    }
+
+    private fun refreshPiPStatus(){
+        val pipSettings = findPreference(getString(R.string.preference_video_pip))
+        if(!PermissionManager.hasPiPPermission(context)){
+            pipSettings.summary = getString(R.string.settings_summary_video_pip_unavailable)
+        } else {
+            pipSettings.summary = ""
         }
     }
 

--- a/app/src/main/java/de/xikolo/controllers/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/settings/SettingsFragment.kt
@@ -23,12 +23,10 @@ import de.xikolo.controllers.dialogs.StorageMigrationDialogAutoBundle
 import de.xikolo.controllers.login.LoginActivityAutoBundle
 import de.xikolo.events.LoginEvent
 import de.xikolo.events.LogoutEvent
+import de.xikolo.managers.PermissionManager
 import de.xikolo.managers.UserManager
 import de.xikolo.services.DownloadService
-import de.xikolo.utils.DeviceUtil
-import de.xikolo.utils.FileUtil
-import de.xikolo.utils.StorageUtil
-import de.xikolo.utils.ToastUtil
+import de.xikolo.utils.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -143,6 +141,24 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             val general = findPreference(getString(R.string.preference_category_general)) as PreferenceCategory
             val storagePref = findPreference(getString(R.string.preference_storage))
             general.removePreference(storagePref)
+        }
+
+        val pipSettings = findPreference(getString(R.string.preference_video_pip))
+        if(!DisplayUtil.supportsPictureInPicture(App.getInstance())){
+            val video = findPreference(getString(R.string.preference_category_video_playback_speed)) as PreferenceCategory
+            video.removePreference(pipSettings)
+        } else {
+            pipSettings.setOnPreferenceClickListener {
+                try {
+                    val intent = Intent("android.settings.PICTURE_IN_PICTURE_SETTINGS")
+                    val uri = Uri.fromParts("package", activity?.packageName, null)
+                    intent.data = uri
+                    activity?.startActivity(intent)
+                } catch (e: RuntimeException) {
+                    PermissionManager.startAppInfo(activity)
+                }
+                true
+            }
         }
 
         val copyright = findPreference(getString(R.string.preference_copyright))

--- a/app/src/main/java/de/xikolo/controllers/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/settings/SettingsFragment.kt
@@ -16,6 +16,7 @@ import de.xikolo.App
 import de.xikolo.BuildConfig
 import de.xikolo.R
 import de.xikolo.config.Config
+import de.xikolo.config.FeatureToggle
 import de.xikolo.controllers.dialogs.ProgressDialogHorizontal
 import de.xikolo.controllers.dialogs.ProgressDialogHorizontalAutoBundle
 import de.xikolo.controllers.dialogs.StorageMigrationDialog
@@ -26,7 +27,10 @@ import de.xikolo.events.LogoutEvent
 import de.xikolo.managers.PermissionManager
 import de.xikolo.managers.UserManager
 import de.xikolo.services.DownloadService
-import de.xikolo.utils.*
+import de.xikolo.utils.DeviceUtil
+import de.xikolo.utils.FileUtil
+import de.xikolo.utils.StorageUtil
+import de.xikolo.utils.ToastUtil
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -47,7 +51,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
     override fun onResume() {
         preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
-        refreshPiPStatus()
+        refreshPipStatus()
         super.onResume()
     }
 
@@ -145,7 +149,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         }
 
         val pipSettings = findPreference(getString(R.string.preference_video_pip))
-        if(!DisplayUtil.supportsPictureInPicture(App.getInstance())){
+        if (!FeatureToggle.pictureInPicture(App.getInstance())) {
             val video = findPreference(getString(R.string.preference_category_video_playback_speed)) as PreferenceCategory
             video.removePreference(pipSettings)
         } else {
@@ -160,7 +164,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
                 }
                 true
             }
-            refreshPiPStatus()
+            refreshPipStatus()
         }
 
         val copyright = findPreference(getString(R.string.preference_copyright))
@@ -232,9 +236,9 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         }
     }
 
-    private fun refreshPiPStatus(){
+    private fun refreshPipStatus(){
         val pipSettings = findPreference(getString(R.string.preference_video_pip))
-        if(!PermissionManager.hasPiPPermission(context)){
+        if(!PermissionManager.hasPipPermission(context)){
             pipSettings.summary = getString(R.string.settings_summary_video_pip_unavailable)
         } else {
             pipSettings.summary = ""

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -19,6 +19,7 @@ import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.NavUtils;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.MediaRouteButton;
 import android.util.DisplayMetrics;
@@ -372,6 +373,8 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
             finishAndRemoveTask();
             parentIntent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
             startActivity(parentIntent);
+        } else {
+            NavUtils.navigateUpFromSameTask(this);
         }
     }
 

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -431,7 +431,7 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
                     this,
                     playing ? android.R.drawable.ic_media_pause : android.R.drawable.ic_media_play),
                 playing ? "Pause" : "Play",
-                playing ? "Pause" : "PPlay",
+                playing ? "Pause" : "Play",
                 pendingIntent
             )
         );
@@ -459,17 +459,16 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
             broadcastReceiver = new BroadcastReceiver() {
                 @Override
                 public void onReceive(Context context, Intent intent) {
-                    if (intent == null || ACTION_SWITCH_PLAYBACK_STATE.equals(intent.getAction())) {
+                    if (intent == null || !ACTION_SWITCH_PLAYBACK_STATE.equals(intent.getAction())) {
                         return;
                     }
 
-
-                    setPictureInPictureParams(getPipParams(videoHelper.isPlaying()));
                     if (videoHelper.isPlaying()) {
                         videoHelper.pause();
                     } else {
                         videoHelper.play();
                     }
+                    setPictureInPictureParams(getPipParams(videoHelper.isPlaying()));
                 }
             };
             registerReceiver(broadcastReceiver, new IntentFilter(ACTION_SWITCH_PLAYBACK_STATE));

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -59,6 +59,7 @@ import de.xikolo.utils.DisplayUtil;
 import de.xikolo.utils.LanalyticsUtil;
 import de.xikolo.utils.MarkdownUtil;
 import de.xikolo.utils.PlayServicesUtil;
+import de.xikolo.utils.ToastUtil;
 
 public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoView> implements VideoView {
 
@@ -135,6 +136,11 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
                 overlay.setOnClickListener(null);
                 overlay.setClickable(false);
                 videoHelper.show();
+            }
+
+            @Override
+            public void onPiPClick() {
+                enterPip(true);
             }
         });
 
@@ -380,20 +386,16 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
 
     @Override
     public void onUserLeaveHint() {
-        if (DisplayUtil.supportsPictureInPicture(this)) {
+        if (DisplayUtil.supportsPictureInPicture(this) && videoHelper.getCurrentPosition() < videoHelper.getDuration() - 5000) {
             super.onUserLeaveHint();
-            enterPip();
+            enterPip(false);
         }
     }
 
     @Override
     public void onBackPressed() {
         if (videoHelper.handleBackPress()) {
-            if (DisplayUtil.supportsPictureInPicture(this) && videoHelper.getCurrentPosition() < videoHelper.getDuration() - 5000) {
-                enterPip();
-            } else {
-                super.onBackPressed();
-            }
+            navigateUp();
         }
     }
 
@@ -431,9 +433,10 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
     }
 
     @TargetApi(26)
-    private void enterPip() {
-        if (hasPipPermissions()) {
-            enterPictureInPictureMode(getPipParams(videoHelper.isPlaying()));
+    private void enterPip(boolean explicitInteraction) {
+        if ((!hasPipPermissions() || !enterPictureInPictureMode(getPipParams(videoHelper.isPlaying())))
+            && explicitInteraction) {
+            ToastUtil.show(R.string.toast_pip_error);
         }
     }
 

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -1,7 +1,6 @@
 package de.xikolo.controllers.video;
 
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.app.AppOpsManager;
 import android.app.PendingIntent;
 import android.app.PictureInPictureParams;
@@ -45,7 +44,6 @@ import butterknife.BindView;
 import de.xikolo.R;
 import de.xikolo.controllers.base.BasePresenterActivity;
 import de.xikolo.controllers.helper.VideoHelper;
-import de.xikolo.managers.PermissionManager;
 import de.xikolo.models.Course;
 import de.xikolo.models.Item;
 import de.xikolo.models.Section;
@@ -57,6 +55,7 @@ import de.xikolo.presenters.video.VideoPresenterFactory;
 import de.xikolo.presenters.video.VideoView;
 import de.xikolo.utils.AndroidDimenUtil;
 import de.xikolo.utils.CastUtil;
+import de.xikolo.utils.DisplayUtil;
 import de.xikolo.utils.LanalyticsUtil;
 import de.xikolo.utils.MarkdownUtil;
 import de.xikolo.utils.PlayServicesUtil;
@@ -85,18 +84,6 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
     private Video video;
 
     private BroadcastReceiver broadcastReceiver;
-
-    @TargetApi(26)
-    private static void openPipSettings(Activity context) {
-        try {
-            Intent intent = new Intent("android.settings.PICTURE_IN_PICTURE_SETTINGS");
-            Uri uri = Uri.fromParts("package", context.getPackageName(), null);
-            intent.setData(uri);
-            context.startActivity(intent);
-        } catch (RuntimeException e) {
-            PermissionManager.startAppInfo(context);
-        }
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -372,7 +359,7 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
 
     @Override
     public void onUserLeaveHint() {
-        if (supportsPip()) {
+        if (DisplayUtil.supportsPictureInPicture(this)) {
             super.onUserLeaveHint();
             enterPip();
         }
@@ -381,7 +368,7 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
     @Override
     public void onBackPressed() {
         if (videoHelper.handleBackPress()) {
-            if (supportsPip()) {
+            if (DisplayUtil.supportsPictureInPicture(this)) {
                 enterPip();
             } else {
                 super.onBackPressed();
@@ -404,10 +391,6 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
             videoHelper.release();
         }
         super.onDestroy();
-    }
-
-    private boolean supportsPip() {
-        return Build.VERSION.SDK_INT >= 26 && getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE);
     }
 
     @TargetApi(26)

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -160,6 +160,14 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
     }
 
     @Override
+    protected void onNewIntent(Intent intent) {
+        if(intent != null) {
+            presenter.onPause(videoHelper.getCurrentPosition());
+            super.onNewIntent(intent);
+        }
+    }
+
+    @Override
     public void setupVideo(Course course, Section section, Item item, Video video) {
         this.video = video;
 

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -454,6 +454,7 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
     @TargetApi(26)
     public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode, Configuration newConfig) {
         if (isInPictureInPictureMode) {
+            videoHelper.hideSettings();
             videoHelper.hide();
             broadcastReceiver = new BroadcastReceiver() {
                 @Override

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -368,7 +368,7 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
     @Override
     public void onBackPressed() {
         if (videoHelper.handleBackPress()) {
-            if (DisplayUtil.supportsPictureInPicture(this)) {
+            if (DisplayUtil.supportsPictureInPicture(this) && videoHelper.getCurrentPosition() < videoHelper.getDuration() - 5000) {
                 enterPip();
             } else {
                 super.onBackPressed();

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -436,8 +436,8 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
                 Icon.createWithResource(
                     this,
                     playing ? android.R.drawable.ic_media_pause : android.R.drawable.ic_media_play),
-                playing ? "Pause" : "Play",
-                playing ? "Pause" : "Play",
+                playing ? getString(R.string.video_pip_action_pause) : getString(R.string.video_pip_action_play),
+                playing ? getString(R.string.video_pip_action_pause) : getString(R.string.video_pip_action_play),
                 pendingIntent
             )
         );

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -11,9 +11,8 @@ import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.graphics.Point;
 import android.graphics.Rect;
-import android.graphics.drawable.Icon;
-import android.net.Uri;
 import android.graphics.Typeface;
+import android.graphics.drawable.Icon;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -40,6 +39,7 @@ import java.util.List;
 
 import butterknife.BindView;
 import de.xikolo.R;
+import de.xikolo.config.FeatureToggle;
 import de.xikolo.controllers.base.BasePresenterActivity;
 import de.xikolo.controllers.helper.VideoHelper;
 import de.xikolo.models.Course;
@@ -53,7 +53,6 @@ import de.xikolo.presenters.video.VideoPresenterFactory;
 import de.xikolo.presenters.video.VideoView;
 import de.xikolo.utils.AndroidDimenUtil;
 import de.xikolo.utils.CastUtil;
-import de.xikolo.utils.DisplayUtil;
 import de.xikolo.utils.LanalyticsUtil;
 import de.xikolo.utils.MarkdownUtil;
 import de.xikolo.utils.PlayServicesUtil;
@@ -137,7 +136,7 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
             }
 
             @Override
-            public void onPiPClick() {
+            public void onPipClick() {
                 enterPip(true);
             }
         });
@@ -384,7 +383,7 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
 
     @Override
     public void onUserLeaveHint() {
-        if (DisplayUtil.supportsPictureInPicture(this) && videoHelper.getCurrentPosition() < videoHelper.getDuration() - 5000) {
+        if (FeatureToggle.pictureInPicture(this) && videoHelper.getCurrentPosition() < videoHelper.getDuration() - 5000) {
             super.onUserLeaveHint();
             enterPip(false);
         }

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -1,7 +1,6 @@
 package de.xikolo.controllers.video;
 
 import android.annotation.TargetApi;
-import android.app.AppOpsManager;
 import android.app.PendingIntent;
 import android.app.PictureInPictureParams;
 import android.app.RemoteAction;
@@ -9,7 +8,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Point;
 import android.graphics.Rect;
@@ -417,24 +415,8 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
     }
 
     @TargetApi(26)
-    private boolean hasPipPermissions() {
-        try {
-            AppOpsManager manager = (AppOpsManager) getSystemService(APP_OPS_SERVICE);
-            if (manager != null && manager.checkOpNoThrow(
-                AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
-                getPackageManager().getApplicationInfo(getPackageName(), PackageManager.GET_META_DATA).uid,
-                getPackageName()
-            ) == AppOpsManager.MODE_ALLOWED) {
-                return true;
-            }
-        } catch (Exception ignored) {
-        }
-        return false;
-    }
-
-    @TargetApi(26)
     private void enterPip(boolean explicitInteraction) {
-        if ((!hasPipPermissions() || !enterPictureInPictureMode(getPipParams(videoHelper.isPlaying())))
+        if (!enterPictureInPictureMode(getPipParams(videoHelper.isPlaying()))
             && explicitInteraction) {
             ToastUtil.show(R.string.toast_pip_error);
         }

--- a/app/src/main/java/de/xikolo/managers/PermissionManager.java
+++ b/app/src/main/java/de/xikolo/managers/PermissionManager.java
@@ -2,6 +2,8 @@ package de.xikolo.managers;
 
 import android.Manifest;
 import android.app.Activity;
+import android.app.AppOpsManager;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -82,4 +84,18 @@ public class PermissionManager {
         activity.startActivity(intent);
     }
 
+    public static boolean hasPiPPermission(Context context) {
+        try {
+            AppOpsManager manager = ContextCompat.getSystemService(context, AppOpsManager.class);
+            if (manager != null && manager.checkOp(
+                AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
+                context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA).uid,
+                context.getPackageName()
+            ) == AppOpsManager.MODE_ALLOWED) {
+                return true;
+            }
+        } catch (Exception ignored) {
+        }
+        return false;
+    }
 }

--- a/app/src/main/java/de/xikolo/managers/PermissionManager.java
+++ b/app/src/main/java/de/xikolo/managers/PermissionManager.java
@@ -1,6 +1,7 @@
 package de.xikolo.managers;
 
 import android.Manifest;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AppOpsManager;
 import android.content.Context;
@@ -84,15 +85,19 @@ public class PermissionManager {
         activity.startActivity(intent);
     }
 
-    public static boolean hasPiPPermission(Context context) {
+    @TargetApi(26)
+    public static boolean hasPipPermission(Context context) {
         try {
             AppOpsManager manager = ContextCompat.getSystemService(context, AppOpsManager.class);
-            if (manager != null && manager.checkOp(
-                AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
-                context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA).uid,
-                context.getPackageName()
-            ) == AppOpsManager.MODE_ALLOWED) {
-                return true;
+            if (manager != null) {
+                int status = manager.checkOp(
+                    AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
+                    context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA).uid,
+                    context.getPackageName()
+                );
+                if (status == AppOpsManager.MODE_ALLOWED) {
+                    return true;
+                }
             }
         } catch (Exception ignored) {
         }

--- a/app/src/main/java/de/xikolo/utils/DisplayUtil.java
+++ b/app/src/main/java/de/xikolo/utils/DisplayUtil.java
@@ -1,8 +1,6 @@
 package de.xikolo.utils;
 
 import android.content.Context;
-import android.content.pm.PackageManager;
-import android.os.Build;
 import android.util.DisplayMetrics;
 
 public class DisplayUtil {
@@ -23,10 +21,6 @@ public class DisplayUtil {
         float dpWidth = displayMetrics.widthPixels / displayMetrics.density;
 
         return dpHeight >= 720 || dpWidth >= 720;
-    }
-
-    public static boolean supportsPictureInPicture(Context context) {
-        return Build.VERSION.SDK_INT >= 26 && context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE);
     }
 
 }

--- a/app/src/main/java/de/xikolo/utils/DisplayUtil.java
+++ b/app/src/main/java/de/xikolo/utils/DisplayUtil.java
@@ -1,6 +1,8 @@
 package de.xikolo.utils;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.util.DisplayMetrics;
 
 public class DisplayUtil {
@@ -21,6 +23,10 @@ public class DisplayUtil {
         float dpWidth = displayMetrics.widthPixels / displayMetrics.density;
 
         return dpHeight >= 720 || dpWidth >= 720;
+    }
+
+    public static boolean supportsPictureInPicture(Context context) {
+        return Build.VERSION.SDK_INT >= 26 && context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE);
     }
 
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -215,7 +215,7 @@
     <string name="toast_file_already_downloaded">Datei bereits heruntergeladen.</string>
     <string name="toast_no_external_write_access">Kein Schreibzugriff für %1$s.</string>
     <string name="toast_no_file_viewer_found">Keine Anwendung zum Öffnen dieser Datei gefunden.</string>
-    <string name="toast_pip_error">Die Anwendung konnte nicht in den Bild Im Bild Modus wechseln.</string>
+    <string name="toast_pip_error">Die Anwendung konnte nicht in den Bild-im-Bild Modus wechseln.</string>
 
     <!-- -->
     <string name="offline_mode">Offline-Modus</string>
@@ -225,7 +225,7 @@
     <string name="video_settings_speed">Wiedergabegeschwindigkeit</string>
     <string name="video_settings_subtitles">Untertitel</string>
     <string name="video_settings_subtitles_none">Keine</string>
-    <string name="video_settings_pip">Bild Im Bild</string>
+    <string name="video_settings_pip">Bild-im-Bild</string>
     <string name="video_settings_subtitles_generated">(automatisch erzeugt)</string>
     <string name="video_description_unavailable">Für dieses Video ist keine Beschreibung vorhanden.</string>
 
@@ -252,7 +252,7 @@
     <string name="settings_title_video_playback_speed">Wiedergabegeschwindigkeit von Videos</string>
     <string name="settings_summary_video_playback_speed">Standard-Geschwindigkeit: %s</string>
 
-    <string name="settings_title_video_pip">Einstellungen für Bild Im Bild</string>
+    <string name="settings_title_video_pip">Einstellungen für Bild-im-Bild</string>
     <string name="settings_summary_video_pip_unavailable">Deaktiviert oder nicht verfügbar</string>
 
     <string name="settings_category_about">Info</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -215,6 +215,7 @@
     <string name="toast_file_already_downloaded">Datei bereits heruntergeladen.</string>
     <string name="toast_no_external_write_access">Kein Schreibzugriff für %1$s.</string>
     <string name="toast_no_file_viewer_found">Keine Anwendung zum Öffnen dieser Datei gefunden.</string>
+    <string name="toast_pip_error">Die Anwendung konnte nicht in den Bild Im Bild Modus wechseln.</string>
 
     <!-- -->
     <string name="offline_mode">Offline-Modus</string>
@@ -224,6 +225,7 @@
     <string name="video_settings_speed">Wiedergabegeschwindigkeit</string>
     <string name="video_settings_subtitles">Untertitel</string>
     <string name="video_settings_subtitles_none">Keine</string>
+    <string name="video_settings_pip">Bild Im Bild</string>
     <string name="video_settings_subtitles_generated">(automatisch erzeugt)</string>
     <string name="video_description_unavailable">Für dieses Video ist keine Beschreibung vorhanden.</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -250,6 +250,8 @@
     <string name="settings_title_video_playback_speed">Wiedergabegeschwindigkeit von Videos</string>
     <string name="settings_summary_video_playback_speed">Standard-Geschwindigkeit: %s</string>
 
+    <string name="settings_title_video_pip">Einstellungen für Bild Im Bild</string>
+
     <string name="settings_category_about">Info</string>
 
     <string name="settings_title_licenses">Open-Source-Lizenzen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -253,6 +253,7 @@
     <string name="settings_summary_video_playback_speed">Standard-Geschwindigkeit: %s</string>
 
     <string name="settings_title_video_pip">Einstellungen für Bild Im Bild</string>
+    <string name="settings_summary_video_pip_unavailable">Deaktiviert oder nicht verfügbar</string>
 
     <string name="settings_category_about">Info</string>
 

--- a/app/src/main/res/values/icons.xml
+++ b/app/src/main/res/values/icons.xml
@@ -34,6 +34,7 @@
     <string name="icon_bonus" translatable="false">&#xe671;</string>
     <string name="icon_survey" translatable="false">&#xe678;</string>
     <string name="icon_pinboard" translatable="false">&#xe604;</string>
+    <string name="icon_pip" translatable="false">&#xe659;</string>
 
     <!-- materialdesign.ttf from https://materialdesignicons.com/ -->
     <string name="icon_step_forward" translatable="false">&#xf467;</string>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -15,6 +15,7 @@
     <string name="preference_download_network" translatable="false">download_network</string>
     <string name="preference_video_playback_speed" translatable="false">video_playback_speed</string>
     <string name="preference_video_subtitles_language" translatable="false">video_subtitles_language</string>
+    <string name="preference_video_pip" translatable="false">video_pip</string>
     <string name="preference_copyright" translatable="false">copyright</string>
     <string name="preference_imprint" translatable="false">imprint</string>
     <string name="preference_privacy" translatable="false">privacy</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,7 +223,7 @@
     <string name="toast_file_already_downloaded">File already downloaded.</string>
     <string name="toast_no_external_write_access">No write access for %1$s.</string>
     <string name="toast_no_file_viewer_found">No application to open this file found.</string>
-    <string name="toast_pip_error">The application could not enter Picture-in-picture mode.</string>
+    <string name="toast_pip_error">The application could not enter Picture-in-Picture mode.</string>
 
     <!-- -->
     <string name="offline_mode">Offline Mode</string>
@@ -234,7 +234,7 @@
     <string name="video_settings_subtitles">Subtitles</string>
     <string name="video_settings_subtitles_none">None</string>
     <string name="video_settings_subtitles_generated">(automatically generated)</string>
-    <string name="video_settings_pip">Picture-in-picture</string>
+    <string name="video_settings_pip">Picture-in-Picture</string>
     <string name="video_settings_separator" translatable="false">&#xb7;</string>
     <string name="video_description_unavailable">There is no description available for this video.</string>
     <string name="video_pip_action_play" translatable="false">Play</string>
@@ -261,7 +261,7 @@
     <string name="settings_title_video_playback_speed">Video playback speed</string>
     <string name="settings_summary_video_playback_speed">Default speed: %s</string>
 
-    <string name="settings_title_video_pip">Settings for Picture-in-picture</string>
+    <string name="settings_title_video_pip">Settings for Picture-in-Picture</string>
     <string name="settings_summary_video_pip_unavailable">Deactivated or not available</string>
 
     <string name="settings_category_about">About</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,6 +237,8 @@
     <string name="video_settings_pip">Picture-in-picture</string>
     <string name="video_settings_separator" translatable="false">&#xb7;</string>
     <string name="video_description_unavailable">There is no description available for this video.</string>
+    <string name="video_pip_action_play" translatable="false">Play</string>
+    <string name="video_pip_action_pause" translatable="false">Pause</string>
 
     <!-- -->
     <string name="media_route_menu_title">CAST</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,6 +257,8 @@
     <string name="settings_title_video_playback_speed">Video playback speed</string>
     <string name="settings_summary_video_playback_speed">Default speed: %s</string>
 
+    <string name="settings_title_video_pip">Settings for Picture-in-picture</string>
+
     <string name="settings_category_about">About</string>
 
     <string name="settings_title_licenses">Open source licenses</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,6 +223,7 @@
     <string name="toast_file_already_downloaded">File already downloaded.</string>
     <string name="toast_no_external_write_access">No write access for %1$s.</string>
     <string name="toast_no_file_viewer_found">No application to open this file found.</string>
+    <string name="toast_pip_error">The application could not go into Picture-in-picture mode.</string>
 
     <!-- -->
     <string name="offline_mode">Offline Mode</string>
@@ -233,6 +234,7 @@
     <string name="video_settings_subtitles">Subtitles</string>
     <string name="video_settings_subtitles_none">None</string>
     <string name="video_settings_subtitles_generated">(automatically generated)</string>
+    <string name="video_settings_pip">Picture-in-picture</string>
     <string name="video_settings_separator" translatable="false">&#xb7;</string>
     <string name="video_description_unavailable">There is no description available for this video.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,7 +223,7 @@
     <string name="toast_file_already_downloaded">File already downloaded.</string>
     <string name="toast_no_external_write_access">No write access for %1$s.</string>
     <string name="toast_no_file_viewer_found">No application to open this file found.</string>
-    <string name="toast_pip_error">The application could not go into Picture-in-picture mode.</string>
+    <string name="toast_pip_error">The application could not enter Picture-in-picture mode.</string>
 
     <!-- -->
     <string name="offline_mode">Offline Mode</string>
@@ -260,6 +260,7 @@
     <string name="settings_summary_video_playback_speed">Default speed: %s</string>
 
     <string name="settings_title_video_pip">Settings for Picture-in-picture</string>
+    <string name="settings_summary_video_pip_unavailable">Deactivated or not available</string>
 
     <string name="settings_category_about">About</string>
 

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -47,6 +47,10 @@
             android:summary="@string/settings_summary_video_playback_speed"
             android:title="@string/settings_title_video_playback_speed" />
 
+        <android.support.v7.preference.Preference
+            android:key="@string/preference_video_pip"
+            android:title="@string/settings_title_video_pip" />
+
     </android.support.v7.preference.PreferenceCategory>
 
     <android.support.v7.preference.PreferenceCategory


### PR DESCRIPTION
Adds support for Picture-In-Picture video playback from SDK 26 up (Oreo 8.0).

If the device supports PiP, the video switches on home or recents tap but not on up navigation and back. There is also an entry to start PiP in video player settings when supported and permitted.
Newly played videos are started in the same `Activity`, so presenter support for `onNewIntent()` was added.
There is also a new element in app settings which leads the user to Android's PiP settings for this app.

Fixes #65 

![pip](https://user-images.githubusercontent.com/26904189/48679881-c30f1480-eb95-11e8-9649-046b74eacd86.gif)
