### PR TITLE
Video-related bugfixes

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoHelper.java
@@ -540,7 +540,7 @@ public class VideoHelper {
                 @Override
                 public void onPipClick() {
                     hideSettings();
-                    if(controllerListener != null) {
+                    if (controllerListener != null) {
                         controllerListener.onPipClick();
                     }
                 }
@@ -620,12 +620,15 @@ public class VideoHelper {
         } else if (videoSettingsHelper.getCurrentQuality() == VideoSettingsHelper.VideoMode.AUTO) { // retry with HD instead of HLS
             videoSettingsHelper.setCurrentQuality(VideoSettingsHelper.VideoMode.HD);
             updateVideo();
+            return;
         } else if (videoSettingsHelper.getCurrentQuality() == VideoSettingsHelper.VideoMode.HD) { // retry with SD instead of HD
             videoSettingsHelper.setCurrentQuality(VideoSettingsHelper.VideoMode.SD);
             updateVideo();
+            return;
         } else {
             viewVideoWarning.setVisibility(View.VISIBLE);
             textVideoWarning.setText(activity.getString(R.string.video_notification_no_offline_video));
+            return;
         }
 
         VideoSubtitles currentSubtitles = videoSettingsHelper.getCurrentVideoSubtitles();

--- a/app/src/main/java/de/xikolo/controllers/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/settings/SettingsFragment.kt
@@ -238,10 +238,12 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
     private fun refreshPipStatus() {
         val pipSettings = findPreference(getString(R.string.preference_video_pip))
-        if (!PermissionManager.hasPipPermission(context)) {
-            pipSettings.summary = getString(R.string.settings_summary_video_pip_unavailable)
-        } else {
-            pipSettings.summary = ""
+        pipSettings?.let {
+            if (!PermissionManager.hasPipPermission(context)) {
+                it.summary = getString(R.string.settings_summary_video_pip_unavailable)
+            } else {
+                it.summary = ""
+            }
         }
     }
 

--- a/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoActivity.java
@@ -20,6 +20,7 @@ import android.support.v4.app.NavUtils;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.MediaRouteButton;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.Display;
 import android.view.MenuItem;
@@ -39,6 +40,7 @@ import java.util.List;
 
 import butterknife.BindView;
 import de.xikolo.R;
+import de.xikolo.config.Config;
 import de.xikolo.config.FeatureToggle;
 import de.xikolo.controllers.base.BasePresenterActivity;
 import de.xikolo.controllers.helper.VideoHelper;
@@ -479,7 +481,13 @@ public class VideoActivity extends BasePresenterActivity<VideoPresenter, VideoVi
             registerReceiver(broadcastReceiver, new IntentFilter(ACTION_SWITCH_PLAYBACK_STATE));
         } else {
             videoHelper.show();
-            unregisterReceiver(broadcastReceiver);
+            try {
+                unregisterReceiver(broadcastReceiver);
+            } catch (IllegalArgumentException e){
+                if (Config.DEBUG){
+                    Log.w(TAG, "Could not unregister PiP playback control BroadcastReceiver: " + e.toString());
+                }
+            }
             broadcastReceiver = null;
             backStackLost = true;
         }


### PR DESCRIPTION
Fixes following common bugs:

- [`SettingsFragment` crash](https://console.firebase.google.com/project/opensap-firebase/crashlytics/app/android:de.xikolo.opensap/issues/5c143502f8b88c2963dbd760?time=last-seven-days) - PiP-status-`Preference` was `null` (probably after a pause-resume action in the app)
- [`ExoPlayerVideoView` crash on `prepare()`](https://console.firebase.google.com/project/opensap-firebase/crashlytics/app/android:de.xikolo.opensap/issues/5c15027bf8b88c2963ed19fc?time=last-seven-days) - Missing `return` statements in `VideoHelper.updateVideo()`'s playback source selection led to subtitle initialization without video source
- [`VideoActivity` PiP crash](https://console.firebase.google.com/project/opensap-firebase/crashlytics/app/android:de.xikolo.opensap/issues/5c153fa1f8b88c2963f3aa56?time=last-seven-days) - PiP playback control `BroadcastReceiver` failed to be unregistered somehow
