### PR TITLE
Fix for missing certificates empty state

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/course/CertificatesFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CertificatesFragment.kt
@@ -105,8 +105,13 @@ class CertificatesFragment : NetworkStateFragment<CourseViewModel>() {
                 }
                 container.addView(dvh.view)
             }
+
+            if (downloadViewHelpers.isEmpty()) {
+                showEmptyMessage(R.string.empty_message_course_certificates)
+            } else {
+                showContent()
+            }
         }
-        showContent()
     }
 
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -304,5 +304,6 @@
     <string name="empty_message_documents_title">Für diesen Kurs sind keine Dokumente verfügbar</string>
     <string name="empty_message_global_announcements_title">Keine Neuigkeiten vorhanden</string>
     <string name="empty_message_course_announcements_title">Für diesen Kurs gibt es keine Neuigkeiten</string>
+    <string name="empty_message_course_certificates">Für diesen Kurs gibt es keine Zertifikate</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -322,5 +322,6 @@
     <string name="empty_message_documents_title">No documents available for this course</string>
     <string name="empty_message_global_announcements_title">No announcements available</string>
     <string name="empty_message_course_announcements_title">No announcements available for this course</string>
+    <string name="empty_message_course_certificates">No certificates available for this course</string>
 
 </resources>


### PR DESCRIPTION
Shows a message "There are no certificates available for this course", if so.

Fixes #124 