### PR TITLE
Fix for disappearing subtitles

### DIFF
--- a/app/src/main/java/de/xikolo/views/ExoPlayerVideoView.kt
+++ b/app/src/main/java/de/xikolo/views/ExoPlayerVideoView.kt
@@ -191,7 +191,7 @@ open class ExoPlayerVideoView : PlayerView {
         val subtitleMediaSource = SingleSampleMediaSource.Factory(dataSourceFactory)
             .createMediaSource(
                 Uri.parse(uri),
-                Format.createTextSampleFormat(null, MimeTypes.TEXT_VTT, C.SELECTION_FLAG_FORCED, language),
+                Format.createTextSampleFormat(null, MimeTypes.TEXT_VTT, C.SELECTION_FLAG_DEFAULT, language),
                 C.TIME_UNSET
             )
 


### PR DESCRIPTION
It seems like the `ExoPlayer` dependency update from [f733151d](https://github.com/openHPI/xikolo-android/commit/f733151d0f6cbd3ec2cb834436d90103e7175818) killed the subtitles feature. This fix makes them show again.