### PR TITLE
UTC information for dates

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/announcement/AnnouncementFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/announcement/AnnouncementFragment.kt
@@ -17,6 +17,7 @@ import de.xikolo.managers.UserManager
 import de.xikolo.models.Announcement
 import de.xikolo.utils.MarkdownUtil
 import de.xikolo.viewmodels.announcement.AnnouncementViewModel
+import de.xikolo.views.DateTextView
 import java.text.DateFormat
 import java.util.*
 
@@ -35,7 +36,7 @@ class AnnouncementFragment : NetworkStateFragment<AnnouncementViewModel>() {
     @BindView(R.id.text)
     internal lateinit var text: TextView
     @BindView(R.id.date)
-    internal lateinit var date: TextView
+    internal lateinit var date: DateTextView
     @BindView(R.id.course_button)
     internal lateinit var courseButton: Button
 
@@ -77,6 +78,7 @@ class AnnouncementFragment : NetworkStateFragment<AnnouncementViewModel>() {
 
         val dateFormat = DateFormat.getDateInstance(DateFormat.LONG, Locale.getDefault())
         date.text = dateFormat.format(announcement.publishedAt)
+        date.setDate(announcement.publishedAt)
 
         MarkdownUtil.formatAndSet(announcement.text, text)
 

--- a/app/src/main/java/de/xikolo/controllers/course/DescriptionFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/DescriptionFragment.kt
@@ -11,8 +11,10 @@ import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
 import de.xikolo.config.GlideApp
 import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.video.VideoStreamPlayerActivityAutoBundle
 import de.xikolo.extensions.observe
 import de.xikolo.models.Course
+import de.xikolo.utils.DateUtil
 import de.xikolo.utils.DisplayUtil
 import de.xikolo.utils.MarkdownUtil
 import de.xikolo.viewmodels.course.DescriptionViewModel
@@ -121,7 +123,9 @@ class DescriptionFragment : NetworkStateFragment<DescriptionViewModel>() {
         }
 
         textDate.text = course.formattedDate
-        textDate.setDateSpan(course.startDate, course.endDate)
+        if (DateUtil.isFuture(course.endDate)) {
+            textDate.setDateSpan(course.startDate, course.endDate)
+        }
 
         textLanguage.text = course.formattedLanguage
         MarkdownUtil.formatAndSet(course.description, textDescription)

--- a/app/src/main/java/de/xikolo/controllers/course/DescriptionFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/DescriptionFragment.kt
@@ -11,13 +11,13 @@ import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
 import de.xikolo.config.GlideApp
 import de.xikolo.controllers.base.NetworkStateFragment
-import de.xikolo.controllers.video.VideoStreamPlayerActivityAutoBundle
 import de.xikolo.extensions.observe
 import de.xikolo.models.Course
 import de.xikolo.utils.DisplayUtil
 import de.xikolo.utils.MarkdownUtil
 import de.xikolo.viewmodels.course.DescriptionViewModel
 import de.xikolo.views.CustomSizeImageView
+import de.xikolo.views.DateTextView
 
 class DescriptionFragment : NetworkStateFragment<DescriptionViewModel>() {
 
@@ -47,7 +47,7 @@ class DescriptionFragment : NetworkStateFragment<DescriptionViewModel>() {
     internal lateinit var textTeacher: TextView
 
     @BindView(R.id.text_date)
-    internal lateinit var textDate: TextView
+    internal lateinit var textDate: DateTextView
 
     @BindView(R.id.text_language)
     internal lateinit var textLanguage: TextView
@@ -115,12 +115,14 @@ class DescriptionFragment : NetworkStateFragment<DescriptionViewModel>() {
                 .load(course.teaserStream.thumbnailUrl)
                 .override(imageVideoThumbnail.forcedWidth, imageVideoThumbnail.forcedHeight)
                 .into(imageVideoThumbnail)
-            course.imageUrl != null                  -> GlideApp.with(this)
+            course.imageUrl != null                                                 -> GlideApp.with(this)
                 .load(course.imageUrl)
                 .into(courseImage)
         }
 
         textDate.text = course.formattedDate
+        textDate.setDateSpan(course.startDate, course.endDate)
+
         textLanguage.text = course.formattedLanguage
         MarkdownUtil.formatAndSet(course.description, textDescription)
 

--- a/app/src/main/java/de/xikolo/controllers/course/SectionListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/SectionListAdapter.kt
@@ -18,6 +18,7 @@ import de.xikolo.models.Section
 import de.xikolo.utils.DateUtil
 import de.xikolo.utils.DisplayUtil
 import de.xikolo.views.AutofitRecyclerView
+import de.xikolo.views.DateTextView
 import de.xikolo.views.SpaceItemDecoration
 import java.text.DateFormat
 import java.util.*
@@ -126,6 +127,7 @@ class SectionListAdapter(private val activity: FragmentActivity,
 
             holder.textModuleNotification.text = String.format(activity.getString(R.string.available_at),
                 dateOut.format(section.startDate))
+            holder.textModuleNotification.setDate(section.startDate)
         } else {
             holder.textModuleNotification.text = activity.getString(R.string.module_notification_no_content)
         }
@@ -159,7 +161,7 @@ class SectionListAdapter(private val activity: FragmentActivity,
         lateinit var viewModuleNotification: View
 
         @BindView(R.id.moduleNotificationLabel)
-        lateinit var textModuleNotification: TextView
+        lateinit var textModuleNotification: DateTextView
 
         @BindView(R.id.downloadBtn)
         lateinit var viewDownloadButton: View

--- a/app/src/main/java/de/xikolo/controllers/dialogs/DateInfoDialog.kt
+++ b/app/src/main/java/de/xikolo/controllers/dialogs/DateInfoDialog.kt
@@ -1,0 +1,42 @@
+package de.xikolo.controllers.dialogs
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import de.xikolo.R
+import de.xikolo.controllers.dialogs.base.BaseDialogFragment
+
+class DateInfoDialog(val title: String, private val localDateText: String, private val utcDateText: String) : BaseDialogFragment() {
+
+    companion object {
+        @JvmField
+        val TAG: String = DateInfoDialog::class.java.simpleName
+    }
+
+    @SuppressLint("InflateParams")
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val view = LayoutInflater.from(context).inflate(R.layout.dialog_date_info, null)
+        val localDate: TextView = view.findViewById(R.id.localDate)
+        val utcDate: TextView = view.findViewById(R.id.utcDate)
+
+        localDate.text = localDateText
+        utcDate.text = utcDateText
+
+        val builder = AlertDialog.Builder(activity!!, R.style.AppTheme_Dialog)
+            .setTitle(title)
+            .setView(view)
+            .setNegativeButton(R.string.dialog_date_info_no) { dialog, _ ->
+                dialog.cancel()
+            }
+            .setCancelable(true)
+
+        val dialog = builder.create()
+        dialog.setCanceledOnTouchOutside(true)
+
+        return dialog
+    }
+
+}

--- a/app/src/main/java/de/xikolo/controllers/main/DateListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/DateListAdapter.kt
@@ -64,9 +64,15 @@ class DateListAdapter(private val onDateClickListener: OnDateClickListener?) : B
                 holder.textType.text = courseDate.getTypeString(App.instance)
 
                 holder.textCourse.text = courseDate.getCourse()?.title
-                holder.container.setOnClickListener {
-                    onDateClickListener?.onCourseClicked(courseDate.courseId)
+
+                if (onDateClickListener != null) {
+                    holder.container.setOnClickListener {
+                        onDateClickListener.onCourseClicked(courseDate.courseId)
+                    }
+                } else {
+                    holder.container.isClickable = false
                 }
+
 
                 if (!showCourse) {
                     holder.textCourse.visibility = View.GONE

--- a/app/src/main/java/de/xikolo/controllers/main/DateListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/DateListAdapter.kt
@@ -13,6 +13,7 @@ import de.xikolo.controllers.base.BaseMetaRecyclerViewAdapter
 import de.xikolo.models.CourseDate
 import de.xikolo.models.DateOverview
 import de.xikolo.utils.TimeUtil
+import de.xikolo.views.DateTextView
 import java.text.DateFormat
 import java.util.*
 
@@ -71,6 +72,10 @@ class DateListAdapter(private val onDateClickListener: OnDateClickListener?) : B
                     }
                 } else {
                     holder.container.isClickable = false
+
+                    courseDate.date?.let {
+                        holder.textDate.setDate(it)
+                    }
                 }
 
 
@@ -127,7 +132,7 @@ class DateListAdapter(private val onDateClickListener: OnDateClickListener?) : B
         lateinit var container: View
 
         @BindView(R.id.textDateDate)
-        lateinit var textDate: TextView
+        lateinit var textDate: DateTextView
 
         @BindView(R.id.textDateType)
         lateinit var textType: TextView

--- a/app/src/main/java/de/xikolo/utils/DateUtil.java
+++ b/app/src/main/java/de/xikolo/utils/DateUtil.java
@@ -2,11 +2,13 @@ package de.xikolo.utils;
 
 import android.util.Log;
 
+import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import de.xikolo.config.Config;
 
@@ -77,6 +79,18 @@ public class DateUtil {
     public static String format(Date date) {
         SimpleDateFormat dateFm = new SimpleDateFormat(XIKOLO_DATE_FORMAT, Locale.getDefault());
         return dateFm.format(date);
+    }
+
+    public static String formatLocal(Date date) {
+        DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG, Locale.getDefault());
+        dateFormat.setTimeZone(Calendar.getInstance().getTimeZone());
+        return dateFormat.format(date);
+    }
+
+    public static String formatUTC(Date date) {
+        DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG, Locale.getDefault());
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat.format(date);
     }
 
     public static int compare(String lhs, String rhs) {

--- a/app/src/main/java/de/xikolo/views/DateTextView.kt
+++ b/app/src/main/java/de/xikolo/views/DateTextView.kt
@@ -1,6 +1,7 @@
 package de.xikolo.views
 
 import android.content.Context
+import android.graphics.drawable.LayerDrawable
 import android.util.AttributeSet
 import android.view.View
 import androidx.appcompat.widget.AppCompatTextView
@@ -62,7 +63,9 @@ class DateTextView : AppCompatTextView, View.OnClickListener {
                 compoundDrawables[0],
                 compoundDrawables[1],
                 compoundDrawables[2],
-                resources.getDrawable(R.drawable.dotted_line, context.theme)
+                (resources.getDrawable(R.drawable.dotted_line, context.theme) as? LayerDrawable)?.apply {
+                    this.setTint(currentTextColor)
+                } ?: compoundDrawables[3]
             )
         } else {
             isClickable = false
@@ -102,7 +105,7 @@ class DateTextView : AppCompatTextView, View.OnClickListener {
         }
 
     override fun onClick(v: View?) {
-        if(valid) {
+        if (valid) {
             (context as? FragmentActivity)?.let {
                 DateInfoDialog(infoTitle, localText, utcText).show(it.supportFragmentManager, DateInfoDialog.TAG)
             }

--- a/app/src/main/java/de/xikolo/views/DateTextView.kt
+++ b/app/src/main/java/de/xikolo/views/DateTextView.kt
@@ -102,8 +102,10 @@ class DateTextView : AppCompatTextView, View.OnClickListener {
         }
 
     override fun onClick(v: View?) {
-        (context as? FragmentActivity)?.let {
-            DateInfoDialog(infoTitle, localText, utcText).show(it.supportFragmentManager, DateInfoDialog.TAG)
+        if(valid) {
+            (context as? FragmentActivity)?.let {
+                DateInfoDialog(infoTitle, localText, utcText).show(it.supportFragmentManager, DateInfoDialog.TAG)
+            }
         }
     }
 

--- a/app/src/main/java/de/xikolo/views/DateTextView.kt
+++ b/app/src/main/java/de/xikolo/views/DateTextView.kt
@@ -63,9 +63,7 @@ class DateTextView : AppCompatTextView, View.OnClickListener {
                 compoundDrawables[0],
                 compoundDrawables[1],
                 compoundDrawables[2],
-                (resources.getDrawable(R.drawable.dotted_line, context.theme) as? LayerDrawable)?.apply {
-                    this.setTint(currentTextColor)
-                } ?: compoundDrawables[3]
+                resources.getDrawable(R.drawable.dotted_line, context.theme)
             )
         } else {
             isClickable = false

--- a/app/src/main/java/de/xikolo/views/DateTextView.kt
+++ b/app/src/main/java/de/xikolo/views/DateTextView.kt
@@ -1,0 +1,71 @@
+package de.xikolo.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.AppCompatTextView
+import de.xikolo.utils.DateUtil
+import java.util.*
+
+
+class DateTextView : AppCompatTextView, View.OnClickListener {
+
+    companion object {
+        private val TAG = DateTextView::class.java.simpleName
+    }
+
+    private var startDate: Date? = null
+    private var endDate: Date? = null
+
+    constructor(context: Context) : super(context) {
+        setOnClickListener(this)
+    }
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
+        setOnClickListener(this)
+    }
+
+    constructor(context: Context, attrs: AttributeSet, defStyle: Int) : super(context, attrs, defStyle) {
+        setOnClickListener(this)
+    }
+
+    fun setDate(date: Date) {
+        startDate = date
+        endDate = null
+    }
+
+    fun setDateSpan(startDate: Date, endDate: Date) {
+        this.startDate = startDate
+        this.endDate = endDate
+    }
+
+    private val message: String
+        get() {
+            return if (startDate != null) {
+                if (endDate != null) { // date span
+                    "${DateUtil.formatLocal(startDate)} - ${DateUtil.formatLocal(endDate)}\n\n${DateUtil.formatUTC(startDate)} - ${DateUtil.formatUTC(endDate)}"
+                } else { // simple date
+                    "${DateUtil.formatLocal(startDate)}\n\n${DateUtil.formatUTC(startDate)}"
+                }
+            } else {
+                ""
+            }
+        }
+
+    override fun isClickable(): Boolean {
+        return true
+    }
+
+    override fun onClick(v: View?) {
+        AlertDialog.Builder(context)
+            .setTitle("Date detail")
+            .setMessage(message)
+            .setCancelable(true)
+            .setPositiveButton(android.R.string.ok) { dialog, _ ->
+                dialog.dismiss()
+            }
+            .show()
+    }
+
+}

--- a/app/src/main/java/de/xikolo/views/DateTextView.kt
+++ b/app/src/main/java/de/xikolo/views/DateTextView.kt
@@ -3,11 +3,12 @@ package de.xikolo.views
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatTextView
+import androidx.fragment.app.FragmentActivity
+import de.xikolo.R
+import de.xikolo.controllers.dialogs.DateInfoDialog
 import de.xikolo.utils.DateUtil
 import java.util.*
-
 
 class DateTextView : AppCompatTextView, View.OnClickListener {
 
@@ -17,6 +18,7 @@ class DateTextView : AppCompatTextView, View.OnClickListener {
 
     private var startDate: Date? = null
     private var endDate: Date? = null
+    private var infoTitle: String = resources.getString(R.string.dialog_date_info_default_title)
 
     constructor(context: Context) : super(context) {
         setOnClickListener(this)
@@ -24,48 +26,85 @@ class DateTextView : AppCompatTextView, View.OnClickListener {
 
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
         setOnClickListener(this)
+        updateAttributes(context, attrs)
     }
 
     constructor(context: Context, attrs: AttributeSet, defStyle: Int) : super(context, attrs, defStyle) {
         setOnClickListener(this)
+        updateAttributes(context, attrs)
     }
 
     fun setDate(date: Date) {
         startDate = date
         endDate = null
+
+        updateView()
     }
 
     fun setDateSpan(startDate: Date, endDate: Date) {
         this.startDate = startDate
         this.endDate = endDate
+
+        updateView()
     }
 
-    private val message: String
+    private fun updateAttributes(context: Context, attrs: AttributeSet) {
+        val attributes = context.obtainStyledAttributes(attrs, R.styleable.DateTextView)
+        infoTitle = attributes.getString(R.styleable.DateTextView_infoTitle)
+            ?: resources.getString(R.string.dialog_date_info_default_title)
+        attributes.recycle()
+    }
+
+    private fun updateView() {
+        if (valid) {
+            isClickable = true
+            setCompoundDrawablesWithIntrinsicBounds(
+                compoundDrawables[0],
+                compoundDrawables[1],
+                compoundDrawables[2],
+                resources.getDrawable(R.drawable.dotted_line, context.theme)
+            )
+        } else {
+            isClickable = false
+            setCompoundDrawables(null, null, null, null)
+        }
+    }
+
+    private val localText: String
         get() {
             return if (startDate != null) {
                 if (endDate != null) { // date span
-                    "${DateUtil.formatLocal(startDate)} - ${DateUtil.formatLocal(endDate)}\n\n${DateUtil.formatUTC(startDate)} - ${DateUtil.formatUTC(endDate)}"
+                    "${DateUtil.formatLocal(startDate)} - \n${DateUtil.formatLocal(endDate)}"
                 } else { // simple date
-                    "${DateUtil.formatLocal(startDate)}\n\n${DateUtil.formatUTC(startDate)}"
+                    DateUtil.formatLocal(startDate)
                 }
             } else {
                 ""
             }
         }
 
-    override fun isClickable(): Boolean {
-        return true
-    }
+    private val utcText: String
+        get() {
+            return if (startDate != null) {
+                if (endDate != null) { // date span
+                    "${DateUtil.formatUTC(startDate)} - \n${DateUtil.formatUTC(endDate)}"
+                } else { // simple date
+                    DateUtil.formatUTC(startDate)
+                }
+            } else {
+                ""
+            }
+        }
+
+    private val valid: Boolean
+        get() {
+            return localText.isNotEmpty() && utcText.isNotEmpty()
+        }
 
     override fun onClick(v: View?) {
-        AlertDialog.Builder(context)
-            .setTitle("Date detail")
-            .setMessage(message)
-            .setCancelable(true)
-            .setPositiveButton(android.R.string.ok) { dialog, _ ->
-                dialog.dismiss()
-            }
-            .show()
+        (context as? FragmentActivity)?.let {
+            DateInfoDialog(infoTitle, localText, utcText).show(it.supportFragmentManager, DateInfoDialog.TAG)
+        }
     }
 
 }

--- a/app/src/main/res/drawable/dotted_line.xml
+++ b/app/src/main/res/drawable/dotted_line.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- dirty hack, but works -->
+    <item
+        android:left="-5000dp"
+        android:right="-5000dp"
+        android:top="-5000dp">
+        <shape android:shape="rectangle">
+            <stroke
+                android:width="1dp"
+                android:color="@color/text_second"
+                android:dashWidth="3dp"
+                android:dashGap="4dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/dotted_line.xml
+++ b/app/src/main/res/drawable/dotted_line.xml
@@ -2,15 +2,18 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- dirty hack, but works -->
     <item
+        android:id="@+id/dotted_line"
         android:left="-5000dp"
         android:right="-5000dp"
         android:top="-5000dp">
-        <shape android:shape="rectangle">
+        <shape
+            android:shape="rectangle"
+            android:tint="@color/text_second">
             <stroke
-                android:width="1dp"
-                android:color="@color/text_second"
-                android:dashWidth="3dp"
+                android:width="2dp"
+                android:dashWidth="2dp"
                 android:dashGap="4dp" />
+            <solid android:color="@color/transparent" />
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/drawable/dotted_line.xml
+++ b/app/src/main/res/drawable/dotted_line.xml
@@ -8,11 +8,11 @@
         android:top="-5000dp">
         <shape
             android:shape="rectangle"
-            android:tint="@color/text_second">
+            android:tint="@color/text_light">
             <stroke
-                android:width="2dp"
+                android:width="1dp"
                 android:dashWidth="2dp"
-                android:dashGap="4dp" />
+                android:dashGap="3dp" />
             <solid android:color="@color/transparent" />
         </shape>
     </item>

--- a/app/src/main/res/layout/container_date_item.xml
+++ b/app/src/main/res/layout/container_date_item.xml
@@ -52,7 +52,7 @@
         android:orientation="horizontal"
         android:paddingTop="2dp">
 
-        <TextView
+        <de.xikolo.views.DateTextView
             android:id="@+id/textDateDate"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/content_announcement.xml
+++ b/app/src/main/res/layout/content_announcement.xml
@@ -1,34 +1,31 @@
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:res="http://schemas.android.com/apk/res-auto"
     android:id="@+id/content_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <RelativeLayout
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:padding="@dimen/content_horizontal_margin">
 
-        <TextView
+        <de.xikolo.views.DateTextView
             android:id="@+id/date"
-            android:layout_width="fill_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
-            android:paddingLeft="16dp"
-            android:paddingRight="16dp"
-            android:paddingTop="16dp"
             android:textColor="@color/text_second"
-            android:textSize="12sp" />
+            android:textSize="12sp"
+            res:infoTitle="@string/dialog_date_info_title_announcement" />
 
         <TextView
             android:id="@+id/text"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
             android:layout_below="@+id/date"
+            android:layout_alignParentLeft="true"
             android:lineSpacingExtra="4dp"
-            android:paddingBottom="16dp"
-            android:paddingLeft="16dp"
-            android:paddingRight="16dp"
             android:paddingTop="4dp"
             android:textColor="@color/text_main"
             android:textColorLink="@color/apptheme_second"
@@ -39,10 +36,8 @@
             style="@style/ButtonContained"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
             android:layout_below="@+id/text"
-            android:layout_marginBottom="16dp"
-            android:layout_marginRight="16dp"
+            android:layout_alignParentRight="true"
             android:layout_marginTop="16dp"
             android:text="@string/btn_continue_course"
             android:visibility="gone" />

--- a/app/src/main/res/layout/content_course_description.xml
+++ b/app/src/main/res/layout/content_course_description.xml
@@ -66,7 +66,8 @@
             android:layout_marginEnd="12dp"
             android:layout_toEndOf="@+id/text_date_icon"
             android:singleLine="true"
-            android:textSize="14sp" />
+            android:textSize="14sp"
+            res:infoTitle="@string/dialog_date_info_title_course" />
 
         <de.xikolo.views.CustomFontTextView
             android:id="@+id/text_lang_icon"

--- a/app/src/main/res/layout/content_course_description.xml
+++ b/app/src/main/res/layout/content_course_description.xml
@@ -57,7 +57,7 @@
             android:textSize="20sp"
             res:customFont="xikolo.ttf" />
 
-        <TextView
+        <de.xikolo.views.DateTextView
             android:id="@+id/text_date"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_date_info.xml
+++ b/app/src/main/res/layout/dialog_date_info.xml
@@ -1,0 +1,38 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingLeft="?attr/dialogPreferredPadding"
+    android:paddingTop="?attr/dialogPreferredPadding"
+    android:paddingRight="?attr/dialogPreferredPadding">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/dialog_date_info_local"
+        android:textColor="@color/text_second"
+        android:textSize="12sp" />
+
+    <TextView
+        android:id="@+id/localDate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/text_main"
+        android:textSize="16sp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/dialog_date_info_utc"
+        android:textColor="@color/text_second"
+        android:textSize="12sp" />
+
+    <TextView
+        android:id="@+id/utcDate"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:textColor="@color/text_main"
+        android:textSize="16sp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_section.xml
+++ b/app/src/main/res/layout/item_section.xml
@@ -107,7 +107,7 @@
                     android:textSize="20sp"
                     res:customFont="xikolo.ttf" />
 
-                <TextView
+                <de.xikolo.views.DateTextView
                     android:id="@+id/moduleNotificationLabel"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -115,7 +115,8 @@
                     android:paddingRight="8dp"
                     android:text="@string/module_notification_no_content"
                     android:textColor="@color/text_light"
-                    android:textSize="16sp" />
+                    android:textSize="16sp"
+                    res:infoTitle="@string/dialog_date_info_title_section" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/item_section.xml
+++ b/app/src/main/res/layout/item_section.xml
@@ -112,7 +112,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
-                    android:paddingRight="8dp"
                     android:text="@string/module_notification_no_content"
                     android:textColor="@color/text_light"
                     android:textSize="16sp"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -122,6 +122,15 @@
     <string name="dialog_course_dates_title">Terminübersicht</string>
     <string name="dialog_course_dates_no">Schließen</string>
 
+    <string name="dialog_date_info_default_title">Details zu Datum</string>
+    <string name="dialog_date_info_local">Lokalzeit</string>
+    <string name="dialog_date_info_utc">Weltzeit</string>
+    <string name="dialog_date_info_no">Schließen</string>
+
+    <string name="dialog_date_info_title_announcement">Veröffentlichungsdatum</string>
+    <string name="dialog_date_info_title_course">Kursdauer</string>
+    <string name="dialog_date_info_title_section">Startdatum</string>
+
     <!-- -->
     <string name="title_activity_module">Module</string>
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -9,6 +9,10 @@
         <attr name="customFont" format="string" />
     </declare-styleable>
 
+    <declare-styleable name="DateTextView">
+        <attr name="infoTitle" format="string" />
+    </declare-styleable>
+
     <declare-styleable name="Theme">
         <attr name="circularImageViewStyle" format="reference" />
     </declare-styleable>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,15 @@
     <string name="dialog_course_dates_title">Course dates</string>
     <string name="dialog_course_dates_no">Close</string>
 
+    <string name="dialog_date_info_default_title">Date details</string>
+    <string name="dialog_date_info_local">Local</string>
+    <string name="dialog_date_info_utc">World time</string>
+    <string name="dialog_date_info_no">Close</string>
+
+    <string name="dialog_date_info_title_announcement">Publishing date</string>
+    <string name="dialog_date_info_title_course">Course duration</string>
+    <string name="dialog_date_info_title_section">Start date</string>
+
     <!-- -->
     <string name="title_activity_module">Module</string>
 


### PR DESCRIPTION
Adds a `DateTextView` which opens a `DateInfoDialog` showing the UTC time in addition to local time of a date.

`DateTextView` is a `TextView` having the functions `setDate(...)` and `setDateSpan(...)` that dash-underlines its text and becomes clickable when one of them has been called. Upon click, the `DateInfoDialog` is opened showing a long format of the date (or date span) in the local and UTC timezone. The title of this dialog can be customized with the `res:infoTitle` xml attribute on `DateTextView`. 

The functionality was added to following places in the app:
- Course > Course Details (only when course end date is in future)
- Course > Learnings (when a section is unavailable)
- Course > Course Dates
- Announcements

<img src="https://user-images.githubusercontent.com/26904189/59564033-1b31ca80-9042-11e9-87fa-6abfd70ee46e.png" width="150px"/> <img src="https://user-images.githubusercontent.com/26904189/59564037-238a0580-9042-11e9-9921-91706995727b.png" width="150px"/> <img src="https://user-images.githubusercontent.com/26904189/59564043-33094e80-9042-11e9-95c3-203d1572d55f.png" width="150px"/> <img src="https://user-images.githubusercontent.com/26904189/59564040-2ab11380-9042-11e9-905d-cf092ccbeb09.png" width="150px"/>

<img src="https://user-images.githubusercontent.com/26904189/59564067-6946ce00-9042-11e9-95a6-c68e1964124e.png" width="300px"/> <img src="https://user-images.githubusercontent.com/26904189/59564068-6c41be80-9042-11e9-93f3-285ce67b9fd1.png" width="300px"/>

Fixes #80 