### PR TITLE
Announcements sync fix

### DIFF
--- a/app/src/main/java/de/xikolo/network/ApiServiceInterface.kt
+++ b/app/src/main/java/de/xikolo/network/ApiServiceInterface.kt
@@ -94,6 +94,9 @@ interface ApiServiceInterface {
     @GET("announcements")
     fun listCourseAnnouncements(@Query("filter[course]") courseId: String): Call<Array<Announcement.JsonModel>>
 
+    @GET("announcements/{id}")
+    fun getAnnouncement(@Path("id") id: String): Call<Announcement.JsonModel>
+
     @PATCH("announcements/{id}")
     fun updateAnnouncement(@Path("id") id: String, @Body item: Announcement.JsonModel): Call<Announcement.JsonModel>
 

--- a/app/src/main/java/de/xikolo/network/jobs/GetAnnouncementJob.kt
+++ b/app/src/main/java/de/xikolo/network/jobs/GetAnnouncementJob.kt
@@ -1,0 +1,34 @@
+package de.xikolo.network.jobs
+
+import android.util.Log
+import de.xikolo.config.Config
+import de.xikolo.network.ApiService
+import de.xikolo.network.jobs.base.NetworkJob
+import de.xikolo.network.jobs.base.NetworkStateLiveData
+import de.xikolo.network.sync.Sync
+import ru.gildor.coroutines.retrofit.awaitResponse
+
+class GetAnnouncementJob(private val announcementId: String, networkState: NetworkStateLiveData, userRequest: Boolean) : NetworkJob(networkState, userRequest) {
+
+    companion object {
+        val TAG: String = GetAnnouncementJob::class.java.simpleName
+    }
+
+    override suspend fun onRun() {
+        val response = ApiService.instance.getAnnouncement(announcementId).awaitResponse()
+
+        if (response.isSuccessful && response.body() != null) {
+            if (Config.DEBUG) Log.i(TAG, "Announcement received")
+
+            Sync.Data.with(response.body()!!)
+                .saveOnly()
+                .run()
+
+            success()
+        } else {
+            if (Config.DEBUG) Log.e(TAG, "Error while fetching course")
+            error()
+        }
+    }
+
+}

--- a/app/src/main/java/de/xikolo/network/jobs/GetAnnouncementJob.kt
+++ b/app/src/main/java/de/xikolo/network/jobs/GetAnnouncementJob.kt
@@ -26,7 +26,7 @@ class GetAnnouncementJob(private val announcementId: String, networkState: Netwo
 
             success()
         } else {
-            if (Config.DEBUG) Log.e(TAG, "Error while fetching course")
+            if (Config.DEBUG) Log.e(TAG, "Error while fetching announcement")
             error()
         }
     }

--- a/app/src/main/java/de/xikolo/network/jobs/ListAnnouncementsJob.kt
+++ b/app/src/main/java/de/xikolo/network/jobs/ListAnnouncementsJob.kt
@@ -27,6 +27,8 @@ class ListAnnouncementsJob(private val courseId: String?, userRequest: Boolean, 
             val sync = Sync.Data.with(response.body()!!)
             if (courseId != null) {
                 sync.addFilter("courseId", courseId)
+            } else {
+                sync.saveOnly()
             }
             sync.run()
 

--- a/app/src/main/java/de/xikolo/viewmodels/announcement/AnnouncementViewModel.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/announcement/AnnouncementViewModel.kt
@@ -3,13 +3,11 @@ package de.xikolo.viewmodels.announcement
 import androidx.lifecycle.LiveData
 import de.xikolo.models.Announcement
 import de.xikolo.models.dao.AnnouncementDao
+import de.xikolo.network.jobs.GetAnnouncementJob
 import de.xikolo.network.jobs.UpdateAnnouncementVisitedJob
 import de.xikolo.viewmodels.base.BaseViewModel
-import de.xikolo.viewmodels.shared.AnnouncementListDelegate
 
 class AnnouncementViewModel(private val announcementId: String) : BaseViewModel() {
-
-    private val announcementListDelegate = AnnouncementListDelegate(realm)
 
     private val announcementsDao = AnnouncementDao(realm)
 
@@ -18,15 +16,19 @@ class AnnouncementViewModel(private val announcementId: String) : BaseViewModel(
     }
 
     override fun onFirstCreate() {
-        announcementListDelegate.requestAnnouncementList(networkState, false)
+        requestAnnouncement(false)
     }
 
     override fun onRefresh() {
-        announcementListDelegate.requestAnnouncementList(networkState, true)
+        requestAnnouncement(true)
     }
 
     fun updateAnnouncementVisited(announcementId: String) {
         UpdateAnnouncementVisitedJob.schedule(announcementId)
+    }
+
+    private fun requestAnnouncement(userRequest: Boolean) {
+        GetAnnouncementJob(announcementId, networkState, userRequest).run()
     }
 
 }


### PR DESCRIPTION
Fixes #150 by loading single `Announcements` off the `/announcements/:id` endpoint instead of loading the entire announcement list.