### PR TITLE
App startup enhancements

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/main/SplashActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/SplashActivity.kt
@@ -2,9 +2,7 @@ package de.xikolo.controllers.main
 
 import android.content.Intent
 import android.net.Uri
-import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat.startActivity
 import androidx.fragment.app.DialogFragment
 import de.xikolo.R
 import de.xikolo.controllers.dialogs.*
@@ -22,6 +20,8 @@ class SplashActivity : AppCompatActivity() {
     companion object {
         val TAG: String = SplashActivity::class.java.simpleName
     }
+
+    private var isActivityVisible = false
 
     private val healthCheckCallback: RequestJobCallback
         get() = object : RequestJobCallback() {
@@ -86,9 +86,16 @@ class SplashActivity : AppCompatActivity() {
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onResume() {
+        super.onResume()
+        isActivityVisible = true
+
         migrateStorage()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        isActivityVisible = false
     }
 
     private fun showApiVersionExpiredDialog() {
@@ -140,8 +147,10 @@ class SplashActivity : AppCompatActivity() {
     }
 
     private fun startApp() {
-        val intent = Intent(this@SplashActivity, MainActivity::class.java)
-        startActivity(intent)
+        if (isActivityVisible) {
+            val intent = Intent(this@SplashActivity, MainActivity::class.java)
+            startActivity(intent)
+        }
         finish()
     }
 

--- a/app/src/main/java/de/xikolo/controllers/main/SplashActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/SplashActivity.kt
@@ -2,8 +2,10 @@ package de.xikolo.controllers.main
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.Lifecycle
 import de.xikolo.R
 import de.xikolo.controllers.dialogs.*
 import de.xikolo.network.jobs.CheckHealthJob
@@ -20,8 +22,6 @@ class SplashActivity : AppCompatActivity() {
     companion object {
         val TAG: String = SplashActivity::class.java.simpleName
     }
-
-    private var isActivityVisible = false
 
     private val healthCheckCallback: RequestJobCallback
         get() = object : RequestJobCallback() {
@@ -86,16 +86,10 @@ class SplashActivity : AppCompatActivity() {
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-        isActivityVisible = true
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
 
         migrateStorage()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        isActivityVisible = false
     }
 
     private fun showApiVersionExpiredDialog() {
@@ -147,7 +141,7 @@ class SplashActivity : AppCompatActivity() {
     }
 
     private fun startApp() {
-        if (isActivityVisible) {
+        if (lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
             val intent = Intent(this@SplashActivity, MainActivity::class.java)
             startActivity(intent)
         }


### PR DESCRIPTION
When opening the app and closing it right away, the window goes away but when the health job finishes, it opens again. This fix keeps track whether the app is visible and only starts the `MainActivity` if the app has not been closed.

<img src="https://user-images.githubusercontent.com/26904189/60842850-6ec4ad80-a1d5-11e9-9c7b-86a10682b14f.gif" width="200px"/>

Also, is there a way to allow the user to use the app in offline mode, when the network is really slow (like EDGE) and the health job times out with `ERROR`? As of now the user has to enter airplane mode, open the app and disable airplane mode again.
