### PR TITLE
Fix ViewModelDialogFragments Crashing

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/dialogs/CourseDateListDialog.kt
+++ b/app/src/main/java/de/xikolo/controllers/dialogs/CourseDateListDialog.kt
@@ -47,7 +47,7 @@ class CourseDateListDialog : ViewModelDialogFragment<DateListViewModel>() {
         recyclerView.adapter = adapter
         recyclerView.setHasFixedSize(true)
 
-        viewModel.dates.observe(viewLifecycleOwner) {
+        viewModel.dates.observe(this) {
             adapter.update(viewModel.sectionedDateList)
             showContent()
         }

--- a/app/src/main/java/de/xikolo/controllers/dialogs/base/ViewModelDialogFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/dialogs/base/ViewModelDialogFragment.kt
@@ -52,7 +52,7 @@ abstract class ViewModelDialogFragment<T : BaseViewModel> : BaseDialogFragment()
 
         networkStateHelper = NetworkStateHelper(activity, view, this)
 
-        viewModel.networkState.observe(viewLifecycleOwner) {
+        viewModel.networkState.observe(this) {
             if (it.code != NetworkCode.STARTED) hideAnyProgress()
             when (it.code) {
                 NetworkCode.STARTED                   -> showAnyProgress()


### PR DESCRIPTION
`getViewLifeCycleOwner()` resulted in a crash because the view lifecycle is not yet initialized when `observe()` is called and we inflate the layout ourselves.