### PR TITLE
Support for external courses

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/base/BaseCourseListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/base/BaseCourseListAdapter.kt
@@ -49,7 +49,7 @@ abstract class BaseCourseListAdapter<M>(val fragment: Fragment, private val onCo
         holder.buttonCourseDetails.visibility = View.VISIBLE
         holder.buttonCourseDetails.setOnClickListener { onCourseButtonClickListener?.onDetailButtonClicked(course.id) }
 
-        if(course.external){
+        if (course.external) {
             holder.layout.setOnClickListener { onCourseButtonClickListener?.onDetailButtonClicked(course.id) }
 
             holder.buttonCourseAction.text = App.instance.getString(R.string.btn_external_course)

--- a/app/src/main/java/de/xikolo/controllers/base/BaseCourseListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/base/BaseCourseListAdapter.kt
@@ -49,7 +49,13 @@ abstract class BaseCourseListAdapter<M>(val fragment: Fragment, private val onCo
         holder.buttonCourseDetails.visibility = View.VISIBLE
         holder.buttonCourseDetails.setOnClickListener { onCourseButtonClickListener?.onDetailButtonClicked(course.id) }
 
-        if (course.isEnrolled && course.accessible) {
+        if(course.external){
+            holder.layout.setOnClickListener { onCourseButtonClickListener?.onDetailButtonClicked(course.id) }
+
+            holder.buttonCourseAction.text = App.instance.getString(R.string.btn_external_course)
+            holder.buttonCourseAction.setOnClickListener { onCourseButtonClickListener?.onExternalButtonClicked(course) }
+
+        } else if (course.isEnrolled && course.accessible) {
             holder.layout.setOnClickListener { onCourseButtonClickListener?.onContinueButtonClicked(course.id) }
 
             holder.buttonCourseAction.text = App.instance.getString(R.string.btn_continue_course)
@@ -79,6 +85,8 @@ abstract class BaseCourseListAdapter<M>(val fragment: Fragment, private val onCo
         fun onContinueButtonClicked(courseId: String)
 
         fun onDetailButtonClicked(courseId: String)
+
+        fun onExternalButtonClicked(course: Course)
     }
 
     class CourseViewHolder(view: View) : RecyclerView.ViewHolder(view) {

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
@@ -1,5 +1,7 @@
 package de.xikolo.controllers.channels
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.FrameLayout
@@ -80,6 +82,10 @@ class ChannelDetailsFragment : NetworkStateFragment<ChannelViewModel>() {
 
             override fun onDetailButtonClicked(courseId: String) {
                 enterCourseDetails(courseId)
+            }
+
+            override fun onExternalButtonClicked(course: Course) {
+                enterExternalCourse(course)
             }
         })
 
@@ -207,6 +213,11 @@ class ChannelDetailsFragment : NetworkStateFragment<ChannelViewModel>() {
 
     private fun enterCourseDetails(courseId: String) {
         val intent = CourseActivityAutoBundle.builder().courseId(courseId).build(App.instance)
+        startActivity(intent)
+    }
+
+    private fun enterExternalCourse(course: Course){
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(course.externalUrl))
         startActivity(intent)
     }
 

--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -139,7 +139,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
 
         if (course.external) {
             setAreaState(CourseArea.External)
-            showCourseExternalBar(course.externalUrl)
+            showCourseExternalBar(course)
 
             enrollButton?.setOnClickListener { enterExternalCourse(course) }
         } else if (!course.isEnrolled) {
@@ -309,12 +309,13 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
         enrollButton?.setText(R.string.btn_enroll)
     }
 
-    private fun showCourseExternalBar(externalUrl: String) {
+    private fun showCourseExternalBar(course: Course) {
         enrollBar?.visibility = View.VISIBLE
         enrollButton?.isEnabled = true
         enrollButton?.isClickable = true
 
-        Uri.parse(externalUrl)?.host?.let {
+        enrollButton?.setText(R.string.btn_external_course)
+        Uri.parse(course.externalUrl)?.host?.let {
             enrollButton?.setText(
                 getString(R.string.btn_external_course_target, it)
             )

--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -1,6 +1,7 @@
 package de.xikolo.controllers.course
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.view.Menu
@@ -136,7 +137,12 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
     private fun setupCourse(course: Course) {
         Crashlytics.setString("course_id", course.id)
 
-        if (!course.isEnrolled) {
+        if(course.external){
+            setAreaState(CourseArea.External)
+            showCourseExternalBar()
+
+            enrollButton?.setOnClickListener { enterExternalCourse(course) }
+        } else if (!course.isEnrolled) {
             setAreaState(CourseArea.Locked)
             showEnrollBar()
         } else if (course.accessible) {
@@ -303,6 +309,13 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
         enrollButton?.setText(R.string.btn_enroll)
     }
 
+    private fun showCourseExternalBar() {
+        enrollBar?.visibility = View.VISIBLE
+        enrollButton?.isEnabled = true
+        enrollButton?.isClickable = true
+        enrollButton?.setText(R.string.btn_external_course)
+    }
+
     private fun showCourseUnavailableEnrollBar() {
         enrollBar?.visibility = View.VISIBLE
         enrollButton?.isEnabled = false
@@ -425,6 +438,11 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
 
             viewModel.unenroll(enrollmentId, enrollmentDeletionNetworkState)
         }
+    }
+
+    private fun enterExternalCourse(course: Course){
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(course.externalUrl))
+        startActivity(intent)
     }
 
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -137,9 +137,9 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
     private fun setupCourse(course: Course) {
         Crashlytics.setString("course_id", course.id)
 
-        if(course.external){
+        if (course.external) {
             setAreaState(CourseArea.External)
-            showCourseExternalBar()
+            showCourseExternalBar(course.externalUrl)
 
             enrollButton?.setOnClickListener { enterExternalCourse(course) }
         } else if (!course.isEnrolled) {
@@ -309,11 +309,16 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
         enrollButton?.setText(R.string.btn_enroll)
     }
 
-    private fun showCourseExternalBar() {
+    private fun showCourseExternalBar(externalUrl: String) {
         enrollBar?.visibility = View.VISIBLE
         enrollButton?.isEnabled = true
         enrollButton?.isClickable = true
-        enrollButton?.setText(R.string.btn_external_course)
+
+        Uri.parse(externalUrl)?.host?.let {
+            enrollButton?.setText(
+                getString(R.string.btn_external_course_target, it)
+            )
+        }
     }
 
     private fun showCourseUnavailableEnrollBar() {
@@ -440,7 +445,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
         }
     }
 
-    private fun enterExternalCourse(course: Course){
+    private fun enterExternalCourse(course: Course) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(course.externalUrl))
         startActivity(intent)
     }

--- a/app/src/main/java/de/xikolo/controllers/helper/CourseNavigationHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/CourseNavigationHelper.kt
@@ -52,4 +52,10 @@ enum class CourseArea(@StringRes val titleRes: Int) {
         }
     }
 
+    object External : State() {
+        init {
+            areas.add(COURSE_DETAILS)
+        }
+    }
+
 }

--- a/app/src/main/java/de/xikolo/controllers/main/CourseListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CourseListAdapter.kt
@@ -83,12 +83,18 @@ class CourseListAdapter(fragment: Fragment, private val courseFilter: CourseList
                     holder.textDescription.text = course.shortAbstract
                     holder.textDescription.visibility = View.VISIBLE
 
-                    if (DateUtil.nowIsBetween(course.startDate, course.endDate)) {
-                        holder.textBanner.visibility = View.VISIBLE
-                        holder.textBanner.text = App.instance.getText(R.string.banner_running)
-                        holder.textBanner.setBackgroundColor(ContextCompat.getColor(App.instance, R.color.banner_green))
-                    } else {
-                        holder.textBanner.visibility = View.GONE
+                    when {
+                        course.external                                         -> {
+                            holder.textBanner.visibility = View.VISIBLE
+                            holder.textBanner.text = App.instance.getText(R.string.banner_external)
+                            holder.textBanner.setBackgroundColor(ContextCompat.getColor(App.instance, R.color.banner_grey))
+                        }
+                        DateUtil.nowIsBetween(course.startDate, course.endDate) -> {
+                            holder.textBanner.visibility = View.VISIBLE
+                            holder.textBanner.text = App.instance.getText(R.string.banner_running)
+                            holder.textBanner.setBackgroundColor(ContextCompat.getColor(App.instance, R.color.banner_green))
+                        }
+                        else                                                    -> holder.textBanner.visibility = View.GONE
                     }
                 } else {
                     holder.textDescription.visibility = View.GONE

--- a/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
@@ -1,5 +1,7 @@
 package de.xikolo.controllers.main
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
@@ -78,6 +80,10 @@ class CourseListFragment : ViewModelMainFragment<CourseListViewModel>() {
 
                 override fun onDetailButtonClicked(courseId: String) {
                     enterCourseDetails(courseId)
+                }
+
+                override fun onExternalButtonClicked(course: Course) {
+                    enterExternalCourse(course)
                 }
             },
             object : CourseListAdapter.OnDateOverviewClickListener {
@@ -214,6 +220,11 @@ class CourseListFragment : ViewModelMainFragment<CourseListViewModel>() {
 
     private fun enterCourseDetails(courseId: String) {
         val intent = CourseActivityAutoBundle.builder().courseId(courseId).build(activity!!)
+        startActivity(intent)
+    }
+
+    private fun enterExternalCourse(course: Course){
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(course.externalUrl))
         startActivity(intent)
     }
 

--- a/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
@@ -223,7 +223,7 @@ class CourseListFragment : ViewModelMainFragment<CourseListViewModel>() {
         startActivity(intent)
     }
 
-    private fun enterExternalCourse(course: Course){
+    private fun enterExternalCourse(course: Course) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(course.externalUrl))
         startActivity(intent)
     }

--- a/app/src/main/java/de/xikolo/models/dao/CourseDao.kt
+++ b/app/src/main/java/de/xikolo/models/dao/CourseDao.kt
@@ -17,16 +17,6 @@ class CourseDao(realm: Realm) : BaseDao<Course>(Course::class, realm) {
         defaultSort = "startDate" to Sort.DESCENDING
     }
 
-    fun all() = all("external" to false)
-
-    fun allEnrolled(): LiveData<List<Course>> =
-        query()
-            .equalTo("external", false)
-            .isNotNull("enrollmentId")
-            .sort("startDate", Sort.DESCENDING)
-            .findAllAsync()
-            .asLiveData()
-
     override fun find(id: String?): LiveData<Course> =
         query()
             .beginGroup()
@@ -56,7 +46,6 @@ class CourseDao(realm: Realm) : BaseDao<Course>(Course::class, realm) {
             fun allWithCertificates(): List<Course> =
                 Realm.getDefaultInstance().use { realm ->
                     realm.where<Course>()
-                        .equalTo("external", false)
                         .sort("startDate", Sort.DESCENDING)
                         .findAll()
                         .asCopy()
@@ -69,7 +58,6 @@ class CourseDao(realm: Realm) : BaseDao<Course>(Course::class, realm) {
             fun search(query: String?, withEnrollment: Boolean): List<Course> =
                 Realm.getDefaultInstance().use { realm ->
                     val realmQuery = realm.where<Course>()
-                        .equalTo("external", false)
                         .beginGroup()
                             .like("title", "*$query*", Case.INSENSITIVE)
                             .or()
@@ -93,7 +81,6 @@ class CourseDao(realm: Realm) : BaseDao<Course>(Course::class, realm) {
             fun allCurrentAndFuture(): List<Course> =
                 Realm.getDefaultInstance().use { realm ->
                     realm.where<Course>()
-                        .equalTo("external", false)
                         .beginGroup()
                             .isNull("endDate")
                             .or()
@@ -107,7 +94,6 @@ class CourseDao(realm: Realm) : BaseDao<Course>(Course::class, realm) {
             fun allCurrentAndPast(): List<Course> =
                 Realm.getDefaultInstance().use { realm ->
                     realm.where<Course>()
-                        .equalTo("external", false)
                         .lessThanOrEqualTo("startDate", Date())
                         .sort("startDate", Sort.DESCENDING)
                         .findAll()
@@ -117,7 +103,6 @@ class CourseDao(realm: Realm) : BaseDao<Course>(Course::class, realm) {
             fun allPast(): List<Course> =
                 Realm.getDefaultInstance().use { realm ->
                     realm.where<Course>()
-                        .equalTo("external", false)
                         .beginGroup()
                             .isNotNull("endDate")
                             .and()
@@ -131,7 +116,6 @@ class CourseDao(realm: Realm) : BaseDao<Course>(Course::class, realm) {
             fun allFuture(): List<Course> =
                 Realm.getDefaultInstance().use { realm ->
                     realm.where<Course>()
-                        .equalTo("external", false)
                         .greaterThan("startDate", Date())
                         .sort("startDate", Sort.ASCENDING)
                         .findAll()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -52,7 +52,8 @@
     <!-- -->
     <string name="btn_enroll">Einschreiben</string>
     <string name="btn_continue_course">Fortsetzen</string>
-    <string name="btn_external_course">Externen Kurs besuchen</string>
+    <string name="btn_external_course">Extern öffnen</string>
+    <string name="btn_external_course_target">Externen Kurs auf %1$s öffnen</string>
     <string name="btn_course_details">Details zeigen</string>
     <string name="btn_channel_courses">Mehr anzeigen</string>
     <string name="btn_channel_slider_more">Mehr Kurse anzeigen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -26,6 +26,7 @@
     <string name="header_my_future_courses">Meine zukünftigen Kurse</string>
     <string name="banner_running">Läuft</string>
     <string name="banner_self_paced">Selbststudium</string>
+    <string name="banner_external">Extern</string>
 
     <!-- -->
     <string name="navigation_drawer_open">Öffne Navigation</string>
@@ -51,6 +52,7 @@
     <!-- -->
     <string name="btn_enroll">Einschreiben</string>
     <string name="btn_continue_course">Fortsetzen</string>
+    <string name="btn_external_course">Externen Kurs besuchen</string>
     <string name="btn_course_details">Details zeigen</string>
     <string name="btn_channel_courses">Mehr anzeigen</string>
     <string name="btn_channel_slider_more">Mehr Kurse anzeigen</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -37,6 +37,7 @@
     <!-- -->
     <string name="btn_enroll">注册该课程</string>
     <string name="btn_continue_course">进入课程</string>
+    <string name="btn_external_course">去外部课程</string>
     <string name="btn_starts_soon">课程未开始</string>
 
     <!-- -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -32,6 +32,7 @@
 
     <color name="banner_yellow">#F5A704</color>
     <color name="banner_green">#8CB30D</color>
+    <color name="banner_grey">#5F5F5F</color>
 
     <color name="progress_green">#80B600</color>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="header_my_future_courses">My upcoming courses</string>
     <string name="banner_running">Running</string>
     <string name="banner_self_paced">Self-paced</string>
+    <string name="banner_external">External</string>
 
     <!-- -->
     <string name="navigation_drawer_open">Open navigation drawer</string>
@@ -52,6 +53,7 @@
     <!-- -->
     <string name="btn_enroll">Enroll</string>
     <string name="btn_continue_course">Continue</string>
+    <string name="btn_external_course">Go to external course</string>
     <string name="btn_course_details">Show details</string>
     <string name="btn_channel_courses">Show more</string>
     <string name="btn_channel_slider_more">Show more courses</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,7 +53,8 @@
     <!-- -->
     <string name="btn_enroll">Enroll</string>
     <string name="btn_continue_course">Continue</string>
-    <string name="btn_external_course">Go to external course</string>
+    <string name="btn_external_course">Open external</string>
+    <string name="btn_external_course_target">Go to external course on %1$s</string>
     <string name="btn_course_details">Show details</string>
     <string name="btn_channel_courses">Show more</string>
     <string name="btn_channel_slider_more">Show more courses</string>


### PR DESCRIPTION
Shows external courses under `All Courses`.

External courses in the list have a banner saying `External` and provide the option to view the course's details in-app or to jump right into the external app/browser.
In the `CourseActivity`, only the `Course Details` tab is shown and the bottom bar allows for visiting the external course. 
Works well with #173 .

<img src="https://user-images.githubusercontent.com/26904189/63971739-8159b580-caa7-11e9-8ae0-4ce543a3c764.jpg" width="200px"/> <img src="https://user-images.githubusercontent.com/26904189/63971933-f88f4980-caa7-11e9-928e-c2ae9551dfcd.jpg" width="200px" /> <img src="https://user-images.githubusercontent.com/26904189/63971939-fb8a3a00-caa7-11e9-8a97-a774b771df6e.jpg" width="200px" />

Fixes #169 