### PR TITLE
Bugfixes

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -172,7 +172,10 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        restartActivity()
+
+        handleCourseDeepLink(intent)?.let {
+            restartActivity()
+        }
     }
 
     private fun handleCourseDeepLink(intent: Intent?): String? {

--- a/app/src/main/java/de/xikolo/controllers/section/CourseItemsActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/CourseItemsActivity.kt
@@ -112,6 +112,7 @@ class CourseItemsActivity : ViewModelActivity<CourseItemsViewModel>() {
         }
 
         viewPager.currentItem = index
+        onItemSelected(index)
     }
 
     private fun onItemSelected(position: Int) {

--- a/app/src/main/java/de/xikolo/network/jobs/ListCoursesJob.kt
+++ b/app/src/main/java/de/xikolo/network/jobs/ListCoursesJob.kt
@@ -28,13 +28,13 @@ class ListCoursesJob(networkState: NetworkStateLiveData, userRequest: Boolean) :
         if (response.isSuccessful && response.body() != null) {
             if (Config.DEBUG) Log.i(TAG, "Courses received")
 
+            Sync.Included.with<Enrollment>(response.body()!!)
+                .run()
             Sync.Data.with(response.body()!!)
                 .setBeforeCommitCallback { realm, model ->
                     val course = realm.where<Course>().equalTo("id", model.id).findFirst()
                     if (course != null) model.description = course.description
                 }
-                .run()
-            Sync.Included.with<Enrollment>(response.body()!!)
                 .run()
 
             success()


### PR DESCRIPTION
Fixes three bugs:

- when  opening the `CourseItemsActivity`, the first item is opened but not marked visited
- when in `CourseItemsActivity` and navigating up, the `MainActivity` appears instead of the `CourseActivity` because `onNewActivity` is called which restarts the activity but it should only do this when it is a Deep Link and not an up Intent
- Fixes #159 . The problem was that the courses were synced before the enrollments, so LiveData was triggered when enrollments were not even loaded (only courses are observed, enrollments not) 


(A fourth known bug, a crash when logging out and the `ProfileFragment` is visible, will be fixed in #166)