### PR TITLE
NetworkStateHelper Refactorings

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/announcement/AnnouncementFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/announcement/AnnouncementFragment.kt
@@ -10,7 +10,7 @@ import android.widget.TextView
 import butterknife.BindView
 import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.controllers.course.CourseActivityAutoBundle
 import de.xikolo.extensions.observe
 import de.xikolo.managers.UserManager
@@ -21,7 +21,7 @@ import de.xikolo.views.DateTextView
 import java.text.DateFormat
 import java.util.*
 
-class AnnouncementFragment : NetworkStateFragment<AnnouncementViewModel>() {
+class AnnouncementFragment : ViewModelFragment<AnnouncementViewModel>() {
 
     companion object {
         val TAG: String = AnnouncementFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/base/ViewModelActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/base/ViewModelActivity.kt
@@ -19,7 +19,7 @@ abstract class ViewModelActivity<T : BaseViewModel> : BaseActivity(), ViewModelC
         initViewModel()
     }
 
-    private fun initViewModel(){
+    private fun initViewModel() {
         initViewModel(this)
         viewModel.onCreate()
     }

--- a/app/src/main/java/de/xikolo/controllers/base/ViewModelFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/base/ViewModelFragment.kt
@@ -1,25 +1,25 @@
-package de.xikolo.controllers.dialogs.base
+package de.xikolo.controllers.base
+
 
 import android.os.Bundle
 import android.view.View
-import de.xikolo.controllers.base.ViewModelCreationInterface
 import de.xikolo.extensions.observe
 import de.xikolo.network.jobs.base.NetworkCode
 import de.xikolo.viewmodels.base.BaseViewModel
 
-abstract class ViewModelDialogFragment<T : BaseViewModel> : NetworkStateDialogFragment(), ViewModelCreationInterface<T> {
+abstract class ViewModelFragment<T : BaseViewModel> : NetworkStateFragment(), ViewModelCreationInterface<T> {
 
     override lateinit var viewModel: T
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        initViewModel(this)
         super.onCreate(savedInstanceState)
+        initViewModel(this)
     }
 
-    override fun onDialogViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onDialogViewCreated(view, savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
-        viewModel.networkState.observe(this) {
+        viewModel.networkState.observe(viewLifecycleOwner) {
             if (it.code != NetworkCode.STARTED) hideAnyProgress()
             when (it.code) {
                 NetworkCode.STARTED                   -> showAnyProgress()

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
@@ -14,7 +14,7 @@ import de.xikolo.App
 import de.xikolo.R
 import de.xikolo.config.GlideApp
 import de.xikolo.controllers.base.BaseCourseListAdapter
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.controllers.course.CourseActivityAutoBundle
 import de.xikolo.controllers.login.LoginActivityAutoBundle
 import de.xikolo.extensions.observe
@@ -30,7 +30,7 @@ import de.xikolo.viewmodels.channel.ChannelViewModel
 import de.xikolo.views.AutofitRecyclerView
 import de.xikolo.views.SpaceItemDecoration
 
-class ChannelDetailsFragment : NetworkStateFragment<ChannelViewModel>() {
+class ChannelDetailsFragment : ViewModelFragment<ChannelViewModel>() {
 
     companion object {
         val TAG: String = ChannelDetailsFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/course/AnnouncementListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/AnnouncementListFragment.kt
@@ -9,14 +9,14 @@ import butterknife.BindView
 import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
 import de.xikolo.controllers.announcement.AnnouncementActivityAutoBundle
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.controllers.main.AnnouncementListAdapter
 import de.xikolo.extensions.observe
 import de.xikolo.models.Announcement
 import de.xikolo.utils.LanalyticsUtil
 import de.xikolo.viewmodels.main.AnnouncementListViewModel
 
-class AnnouncementListFragment : NetworkStateFragment<AnnouncementListViewModel>() {
+class AnnouncementListFragment : ViewModelFragment<AnnouncementListViewModel>() {
 
     companion object {
         val TAG: String = AnnouncementListFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/course/CertificatesFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CertificatesFragment.kt
@@ -8,7 +8,7 @@ import androidx.core.widget.TextViewCompat
 import butterknife.BindView
 import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.controllers.helper.DownloadViewHelper
 import de.xikolo.extensions.observe
 import de.xikolo.models.Course
@@ -17,7 +17,7 @@ import de.xikolo.models.Enrollment
 import de.xikolo.models.dao.EnrollmentDao
 import de.xikolo.viewmodels.course.CertificateListViewModel
 
-class CertificatesFragment : NetworkStateFragment<CertificateListViewModel>() {
+class CertificatesFragment : ViewModelFragment<CertificateListViewModel>() {
 
     companion object {
         val TAG: String = CertificatesFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -192,7 +192,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
             val tab = DeepLinkingUtil.getTab(intent.data?.path)
             if (!areaState.areas.contains(tab)) {
                 if (!UserManager.isAuthorized) {
-                    showLoginRequiredMessage()
+                    showLoginRequiredToast()
                 } else {
                     showDeepLinkErrorMessage()
                 }
@@ -226,7 +226,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
                     }
                 GetItemWithContentJob(itemId, viewModel.networkState, false).run()
             } else {
-                showLoginRequiredMessage()
+                showLoginRequiredToast()
                 createChooserFromCurrentIntent()
             }
         }
@@ -374,7 +374,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
         ToastUtil.show(R.string.toast_no_network)
     }
 
-    private fun showLoginRequiredMessage() {
+    private fun showLoginRequiredToast() {
         ToastUtil.show(R.string.toast_please_log_in)
     }
 
@@ -406,7 +406,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
                     }
                     NetworkCode.NO_AUTH    -> {
                         hideProgressDialog()
-                        showLoginRequiredMessage()
+                        showLoginRequiredToast()
                         openLogin()
                         true
                     }

--- a/app/src/main/java/de/xikolo/controllers/course/DescriptionFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/DescriptionFragment.kt
@@ -10,7 +10,7 @@ import butterknife.BindView
 import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
 import de.xikolo.config.GlideApp
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.controllers.video.VideoStreamPlayerActivityAutoBundle
 import de.xikolo.extensions.observe
 import de.xikolo.models.Course
@@ -21,7 +21,7 @@ import de.xikolo.viewmodels.course.DescriptionViewModel
 import de.xikolo.views.CustomSizeImageView
 import de.xikolo.views.DateTextView
 
-class DescriptionFragment : NetworkStateFragment<DescriptionViewModel>() {
+class DescriptionFragment : ViewModelFragment<DescriptionViewModel>() {
 
     companion object {
         val TAG: String = DescriptionFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/course/DocumentListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/DocumentListFragment.kt
@@ -8,11 +8,11 @@ import androidx.recyclerview.widget.RecyclerView
 import butterknife.BindView
 import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.extensions.observe
 import de.xikolo.viewmodels.course.DocumentListViewModel
 
-class DocumentListFragment : NetworkStateFragment<DocumentListViewModel>() {
+class DocumentListFragment : ViewModelFragment<DocumentListViewModel>() {
 
     @AutoBundleField
     lateinit var courseId: String

--- a/app/src/main/java/de/xikolo/controllers/course/LearningsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/LearningsFragment.kt
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.RecyclerView
 import butterknife.BindView
 import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.controllers.helper.SectionDownloadHelper
 import de.xikolo.controllers.section.CourseItemsActivityAutoBundle
 import de.xikolo.extensions.observe
@@ -17,7 +17,7 @@ import de.xikolo.models.dao.SectionDao
 import de.xikolo.viewmodels.course.LearningsViewModel
 import de.xikolo.views.SpaceItemDecoration
 
-class LearningsFragment : NetworkStateFragment<LearningsViewModel>(), SectionListAdapter.OnSectionClickListener, ItemListAdapter.OnItemClickListener {
+class LearningsFragment : ViewModelFragment<LearningsViewModel>(), SectionListAdapter.OnSectionClickListener, ItemListAdapter.OnItemClickListener {
 
     companion object {
         val TAG: String = LearningsFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/course/ProgressFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/ProgressFragment.kt
@@ -6,13 +6,13 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.extensions.observe
 import de.xikolo.models.dao.CourseProgressDao
 import de.xikolo.viewmodels.course.ProgressViewModel
 import de.xikolo.views.SpaceItemDecoration
 
-class ProgressFragment : NetworkStateFragment<ProgressViewModel>() {
+class ProgressFragment : ViewModelFragment<ProgressViewModel>() {
 
     companion object {
         val TAG: String = ProgressFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/dialogs/base/NetworkStateDialogFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/dialogs/base/NetworkStateDialogFragment.kt
@@ -1,0 +1,41 @@
+package de.xikolo.controllers.dialogs.base
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import butterknife.ButterKnife
+import de.xikolo.controllers.helper.NetworkStateHelper
+
+abstract class NetworkStateDialogFragment : BaseDialogFragment(), SwipeRefreshLayout.OnRefreshListener, NetworkStateHelper.NetworkStateOwner {
+
+    abstract val layoutResource: Int
+
+    override lateinit var networkStateHelper: NetworkStateHelper
+
+    protected lateinit var dialogView: View
+        private set
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        dialogView = createView(LayoutInflater.from(activity), null, savedInstanceState)
+
+        onDialogViewCreated(dialogView, savedInstanceState)
+    }
+
+    private fun createView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return inflateHelper(inflater, container, layoutResource)
+    }
+
+    open fun onDialogViewCreated(view: View, savedInstanceState: Bundle?) {
+        ButterKnife.bind(this, view)
+
+        networkStateHelper = NetworkStateHelper(activity, view, this)
+    }
+
+    abstract override fun onCreateDialog(savedInstanceState: Bundle?): Dialog
+
+}

--- a/app/src/main/java/de/xikolo/controllers/login/LoginFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/login/LoginFragment.kt
@@ -23,7 +23,7 @@ import de.xikolo.config.BuildFlavor
 import de.xikolo.config.Config
 import de.xikolo.config.FeatureConfig
 import de.xikolo.config.GlideApp
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.controllers.dialogs.ProgressDialogIndeterminate
 import de.xikolo.controllers.dialogs.ProgressDialogIndeterminateAutoBundle
 import de.xikolo.events.LoginEvent
@@ -35,7 +35,7 @@ import de.xikolo.utils.ToastUtil
 import de.xikolo.viewmodels.login.LoginViewModel
 import org.greenrobot.eventbus.EventBus
 
-class LoginFragment : NetworkStateFragment<LoginViewModel>() {
+class LoginFragment : ViewModelFragment<LoginViewModel>() {
 
     companion object {
         val TAG: String = LoginFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/main/CertificateListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CertificateListFragment.kt
@@ -96,12 +96,6 @@ class CertificateListFragment : ViewModelMainFragment<CertificateListViewModel>(
         }
     }
 
-    private fun showLoginRequired() {
-        showLoginRequired {
-            activityCallback?.selectDrawerSection(R.id.navigation_login)
-        }
-    }
-
     private fun showNoCertificatesMessage() {
         showMessage(R.string.notification_no_certificates, R.string.notification_no_certificates_summary) {
             activityCallback?.selectDrawerSection(R.id.navigation_all_courses)

--- a/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
@@ -266,12 +266,6 @@ class CourseListFragment : ViewModelMainFragment<CourseListViewModel>() {
         startActivity(intent)
     }
 
-    private fun showLoginRequired() {
-        showLoginRequired {
-            activityCallback?.selectDrawerSection(R.id.navigation_login)
-        }
-    }
-
     private fun showNoEnrollmentsMessage() {
         showMessage(R.string.notification_no_enrollments, R.string.notification_no_enrollments_summary) {
             activityCallback?.selectDrawerSection(R.id.navigation_all_courses)

--- a/app/src/main/java/de/xikolo/controllers/main/DateListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/DateListFragment.kt
@@ -82,12 +82,6 @@ class DateListFragment : ViewModelMainFragment<DateListViewModel>() {
         showContent()
     }
 
-    private fun showLoginRequired() {
-        showLoginRequired {
-            activityCallback?.selectDrawerSection(R.id.navigation_login)
-        }
-    }
-
     @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onLogoutEvent(event: LogoutEvent) {

--- a/app/src/main/java/de/xikolo/controllers/main/ViewModelMainFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/ViewModelMainFragment.kt
@@ -1,9 +1,10 @@
 package de.xikolo.controllers.main
 
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.R
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.viewmodels.base.BaseViewModel
 
-abstract class ViewModelMainFragment<T : BaseViewModel> : NetworkStateFragment<T>() {
+abstract class ViewModelMainFragment<T : BaseViewModel> : ViewModelFragment<T>() {
 
     var activityCallback: MainActivityCallback? = null
 
@@ -19,6 +20,12 @@ abstract class ViewModelMainFragment<T : BaseViewModel> : NetworkStateFragment<T
     override fun onStop() {
         super.onStop()
         activityCallback = null
+    }
+
+    protected fun showLoginRequired() {
+        showLoginRequired {
+            activityCallback?.selectDrawerSection(R.id.navigation_login)
+        }
     }
 
 }

--- a/app/src/main/java/de/xikolo/controllers/section/RichTextFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/RichTextFragment.kt
@@ -8,7 +8,7 @@ import butterknife.BindView
 import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
 import de.xikolo.config.Config
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.controllers.webview.WebViewActivityAutoBundle
 import de.xikolo.extensions.observe
 import de.xikolo.models.Item
@@ -16,7 +16,7 @@ import de.xikolo.utils.LanalyticsUtil
 import de.xikolo.utils.MarkdownUtil
 import de.xikolo.viewmodels.section.RichTextViewModel
 
-class RichTextFragment : NetworkStateFragment<RichTextViewModel>() {
+class RichTextFragment : ViewModelFragment<RichTextViewModel>() {
 
     companion object {
         val TAG: String = RichTextFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
@@ -11,7 +11,7 @@ import butterknife.BindView
 import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
 import de.xikolo.config.GlideApp
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.controllers.helper.DownloadViewHelper
 import de.xikolo.controllers.video.VideoItemPlayerActivityAutoBundle
 import de.xikolo.extensions.observe
@@ -25,7 +25,7 @@ import de.xikolo.viewmodels.section.VideoPreviewViewModel
 import de.xikolo.views.CustomSizeImageView
 import java.util.concurrent.TimeUnit
 
-class VideoPreviewFragment : NetworkStateFragment<VideoPreviewViewModel>() {
+class VideoPreviewFragment : ViewModelFragment<VideoPreviewViewModel>() {
 
     companion object {
         val TAG: String = VideoPreviewFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/video/VideoDescriptionFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoDescriptionFragment.kt
@@ -6,12 +6,12 @@ import android.view.View
 import android.widget.TextView
 import butterknife.BindView
 import de.xikolo.R
-import de.xikolo.controllers.base.NetworkStateFragment
+import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.extensions.observe
 import de.xikolo.utils.MarkdownUtil
 import de.xikolo.viewmodels.section.VideoDescriptionViewModel
 
-class VideoDescriptionFragment(val itemId: String, val videoId: String) : NetworkStateFragment<VideoDescriptionViewModel>() {
+class VideoDescriptionFragment(val itemId: String, val videoId: String) : ViewModelFragment<VideoDescriptionViewModel>() {
 
     companion object {
         val TAG: String = VideoDescriptionFragment::class.java.simpleName

--- a/app/src/main/java/de/xikolo/controllers/webview/WebViewFragment.java
+++ b/app/src/main/java/de/xikolo/controllers/webview/WebViewFragment.java
@@ -16,8 +16,6 @@ import androidx.annotation.Nullable;
 import com.crashlytics.android.Crashlytics;
 import com.yatatsu.autobundle.AutoBundleField;
 
-import org.jetbrains.annotations.NotNull;
-
 import de.xikolo.App;
 import de.xikolo.R;
 import de.xikolo.config.Config;
@@ -26,9 +24,8 @@ import de.xikolo.controllers.helper.WebViewHelper;
 import de.xikolo.controllers.login.LoginActivityAutoBundle;
 import de.xikolo.utils.NetworkUtil;
 import de.xikolo.utils.ToastUtil;
-import de.xikolo.viewmodels.base.NullViewModel;
 
-public class WebViewFragment extends NetworkStateFragment<NullViewModel> {
+public class WebViewFragment extends NetworkStateFragment {
 
     public static final String TAG = WebViewFragment.class.getSimpleName();
 
@@ -41,12 +38,6 @@ public class WebViewFragment extends NetworkStateFragment<NullViewModel> {
     private WebViewHelper webViewHelper;
 
     private MutableContextWrapper mutableContextWrapper;
-
-    @NotNull
-    @Override
-    public NullViewModel createViewModel() {
-        return new NullViewModel();
-    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/de/xikolo/viewmodels/base/NullViewModel.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/base/NullViewModel.kt
@@ -1,7 +1,0 @@
-package de.xikolo.viewmodels.base
-
-class NullViewModel : BaseViewModel() {
-
-    override fun onRefresh() {}
-
-}


### PR DESCRIPTION
The former `NetworkStateFragment` has been split up into the `NetworkStateFragment` and `ViewModelFragment` with latter inheriting from the former. The `NetworkStateFragment` now provides functionality regarding refreshing and the `NetworkStateHelper`. The `ViewModelFragment` builds upon that and adds ViewModel-specific functionality. This allows the `WebViewFragment` to directly inherit from the `NetworkStateFragment`. Thus it does not need a ViewModel anymore and the `NullViewModel` has been removed.
There is now an `interface NetworkStateOwner` which implements shorthand functionality specific to the `NetworkStateHelper`. This helps reducing duplication and separates concerns.

Fixes #160 