### PR TITLE
Fix for broken video scaling in Exoplayer

### DIFF
--- a/app/src/main/java/de/xikolo/views/ExoPlayerVideoView.kt
+++ b/app/src/main/java/de/xikolo/views/ExoPlayerVideoView.kt
@@ -226,7 +226,7 @@ open class ExoPlayerVideoView : PlayerView {
     }
 
     fun scaleToFill() {
-        resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL
+        resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
         exoplayer.videoScalingMode = C.VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING
     }
 


### PR DESCRIPTION
Apparently one of the latest dependency updates again broke an Exoplayer feature.
Videos were no longer scaled retaining their aspect ratio but stretched to fit. A flag change fixes this to have the intended behavior of a zoom effect keeping the ratio intact.