### PR TITLE
Fix for ViewModelDialogFragment crashes

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/dialogs/base/NetworkStateDialogFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/dialogs/base/NetworkStateDialogFragment.kt
@@ -22,8 +22,11 @@ abstract class NetworkStateDialogFragment : BaseDialogFragment(), SwipeRefreshLa
         super.onCreate(savedInstanceState)
 
         dialogView = createView(LayoutInflater.from(activity), null, savedInstanceState)
+    }
 
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         onDialogViewCreated(dialogView, savedInstanceState)
+        return dialogView
     }
 
     private fun createView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/java/de/xikolo/controllers/dialogs/base/ViewModelDialogFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/dialogs/base/ViewModelDialogFragment.kt
@@ -12,8 +12,8 @@ abstract class ViewModelDialogFragment<T : BaseViewModel> : NetworkStateDialogFr
     override lateinit var viewModel: T
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        initViewModel(this)
         super.onCreate(savedInstanceState)
+        initViewModel(this)
     }
 
     override fun onDialogViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
An initialization order error introduced in #176 made the dialog crash upon opening because values were uninitialized. 