### PR TITLE
Compatibility with Android 10 (API29)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ dist: trusty
 group: deprecated-2017Q4
 
 before_install:
-  - yes | sdkmanager "platforms;android-28"
+  - yes | sdkmanager "platforms;android-29"
 
 android:
   components:
     - tools
     - platform-tools
     - tools # called twice to get the newest android sdk tools
-    - build-tools-28.0.3
-    - android-28
+    - build-tools-29.0.2
+    - android-29
     - extra-android-m2repository
     - extra-google-m2repository
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ buildscript {
     ext {
         // shared build properties
         kotlinVersion       = "1.3.41"
-        buildToolsVersion   = "28.0.3"
+        buildToolsVersion   = "29.0.2"
         minSdkVersion       = 21
-        targetSdkVersion    = 28
-        compileSdkVersion   = 28
+        targetSdkVersion    = 29
+        compileSdkVersion   = 29
 
         versionName         = "2.4.1"
         versionCode         = 48


### PR DESCRIPTION
`targetSdkVersion`, `compileSdkVersion` and build tools have been updated to API 29. There should be no limitations.

Fixes #183 