### PR TITLE
v3.0 CourseListAdapter crashes

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/base/BaseMetaRecyclerViewAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/base/BaseMetaRecyclerViewAdapter.kt
@@ -20,10 +20,10 @@ abstract class BaseMetaRecyclerViewAdapter<M, S> : RecyclerView.Adapter<Recycler
         const val ITEM_VIEW_TYPE_ITEM = 2
     }
 
-    protected var contentList: MetaSectionList<String, M, List<S>> = MetaSectionList()
+    protected val contentList: MetaSectionList<String, M, List<S>> = MetaSectionList()
 
     fun update(contentList: MetaSectionList<String, M, List<S>>) {
-        this.contentList = contentList
+        this.contentList.replace(contentList)
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/de/xikolo/controllers/course/ItemListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/ItemListAdapter.kt
@@ -20,10 +20,11 @@ class ItemListAdapter(private val section: Section, private val listener: OnItem
         val TAG: String = ItemListAdapter::class.java.simpleName
     }
 
-    private var items: List<Item> = arrayListOf()
+    private val items: MutableList<Item> = mutableListOf()
 
     fun updateItems(items: List<Item>) {
-        this.items = items
+        this.items.clear()
+        this.items.addAll(items)
         this.notifyDataSetChanged()
     }
 

--- a/app/src/main/java/de/xikolo/controllers/course/SectionListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/SectionListAdapter.kt
@@ -32,10 +32,11 @@ class SectionListAdapter(private val activity: FragmentActivity,
         val TAG: String = SectionListAdapter::class.java.simpleName
     }
 
-    private var sections: List<Section> = arrayListOf()
+    private val sections: MutableList<Section> = mutableListOf()
 
     fun updateSections(sections: List<Section>) {
-        this.sections = sections
+        this.sections.clear()
+        this.sections.addAll(sections)
         this.notifyDataSetChanged()
     }
 

--- a/app/src/main/java/de/xikolo/controllers/main/AnnouncementListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/AnnouncementListAdapter.kt
@@ -19,10 +19,11 @@ class AnnouncementListAdapter(private val announcementClickListener: (String) ->
         val TAG: String = AnnouncementListAdapter::class.java.simpleName
     }
 
-    private var announcementList: List<Announcement> = listOf()
+    private val announcementList: MutableList<Announcement> = mutableListOf()
 
     fun update(announcementList: List<Announcement>) {
-        this.announcementList = announcementList
+        this.announcementList.clear()
+        this.announcementList.addAll(announcementList)
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/de/xikolo/controllers/main/CertificateListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CertificateListAdapter.kt
@@ -14,7 +14,6 @@ import de.xikolo.controllers.helper.DownloadViewHelper
 import de.xikolo.models.Course
 import de.xikolo.models.DownloadAsset
 import de.xikolo.models.dao.EnrollmentDao
-import java.util.*
 
 class CertificateListAdapter(private val fragment: CertificateListFragment, private val callback: OnCertificateCardClickListener) : RecyclerView.Adapter<CertificateListAdapter.CertificateViewHolder>() {
 
@@ -22,10 +21,11 @@ class CertificateListAdapter(private val fragment: CertificateListFragment, priv
         val TAG: String = CertificateListAdapter::class.java.simpleName
     }
 
-    private var courseList: List<Course> = ArrayList()
+    private val courseList: MutableList<Course> = mutableListOf()
 
     fun update(courseList: List<Course>) {
-        this.courseList = courseList
+        this.courseList.clear()
+        this.courseList.addAll(courseList)
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/de/xikolo/controllers/main/ChannelListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/ChannelListAdapter.kt
@@ -23,19 +23,23 @@ class ChannelListAdapter(private val callback: OnChannelCardClickListener) : Rec
         const val PREVIEW_COURSES_COUNT = 7
     }
 
-    private var channelList: List<Channel> = listOf()
+    private var channelList: MutableList<Channel> = mutableListOf()
 
-    private var courseLists: List<List<Course>> = listOf(listOf())
+    private val courseLists: MutableList<List<Course>> = mutableListOf(listOf())
 
     fun update(channelList: List<Channel>, courseLists: List<List<Course>>) {
-        this.channelList = channelList
-        this.courseLists = courseLists
+        this.channelList.clear()
+        this.channelList.addAll(channelList)
+
+        this.courseLists.clear()
+        this.courseLists.addAll(courseLists)
+
         this.notifyDataSetChanged()
     }
 
     fun clear() {
-        channelList = listOf()
-        courseLists = listOf(listOf())
+        channelList.clear()
+        courseLists.clear()
         this.notifyDataSetChanged()
     }
 

--- a/app/src/main/java/de/xikolo/utils/MetaSectionList.kt
+++ b/app/src/main/java/de/xikolo/utils/MetaSectionList.kt
@@ -5,8 +5,11 @@ class MetaSectionList<H, M, S : List<*>>(private var metaItem: M? = null, privat
     private val headers: MutableList<H?> = mutableListOf()
     private val sections: MutableList<S> = mutableListOf()
 
-    private val hasMetaItem = metaItem != null
-    private val hasMetaHeader = metaHeader != null
+    private val hasMetaItem: Boolean
+        get() = metaItem != null
+
+    private val hasMetaHeader: Boolean
+        get() = metaHeader != null
 
     private val metaOffset
         get() = (if (hasMetaItem) 1 else 0) + if (hasMetaHeader) 1 else 0

--- a/app/src/main/java/de/xikolo/utils/MetaSectionList.kt
+++ b/app/src/main/java/de/xikolo/utils/MetaSectionList.kt
@@ -1,6 +1,6 @@
 package de.xikolo.utils
 
-class MetaSectionList<H, out M, S : List<*>>(private var metaItem: M? = null, private var metaHeader: H? = null) {
+class MetaSectionList<H, M, S : List<*>>(private var metaItem: M? = null, private var metaHeader: H? = null) {
 
     private val headers: MutableList<H?> = mutableListOf()
     private val sections: MutableList<S> = mutableListOf()
@@ -19,6 +19,15 @@ class MetaSectionList<H, out M, S : List<*>>(private var metaItem: M? = null, pr
         metaHeader = null
         headers.clear()
         sections.clear()
+    }
+
+    fun replace(list: MetaSectionList<H, M, S>) {
+        metaItem = list.metaItem
+        metaHeader = list.metaHeader
+        headers.clear()
+        headers.addAll(list.headers)
+        sections.clear()
+        sections.addAll(list.sections)
     }
 
     fun add(header: H?, section: S) {

--- a/app/src/test/java/de/xikolo/testing/unit/MetaSectionListTest.kt
+++ b/app/src/test/java/de/xikolo/testing/unit/MetaSectionListTest.kt
@@ -56,11 +56,11 @@ class MetaSectionListTest {
 
         list.clear()
 
-        assertTrue(list.size == 1)
+        assertTrue(list.size == 0)
 
         list.add(null, listOf("item"))
 
-        assertTrue(list.size == 3)
+        assertTrue(list.size == 2)
     }
 
     @Test
@@ -85,11 +85,11 @@ class MetaSectionListTest {
 
         list.clear()
 
-        assertTrue(list.size == 2)
+        assertTrue(list.size == 0)
 
         list.add(null, listOf("item"))
 
-        assertTrue(list.size == 4)
+        assertTrue(list.size == 2)
     }
 
     @Test

--- a/app/src/test/java/de/xikolo/testing/unit/MetaSectionListTest.kt
+++ b/app/src/test/java/de/xikolo/testing/unit/MetaSectionListTest.kt
@@ -91,4 +91,18 @@ class MetaSectionListTest {
 
         assertTrue(list.size == 4)
     }
+
+    @Test
+    fun testReplace() {
+        list = MetaSectionList("meta item", "meta header")
+        list.add("header", listOf("item1", "item2", "item3"))
+
+        val anotherList = MetaSectionList<String, String, List<String>>("another meta item", "another meta header")
+
+        list.replace(anotherList)
+
+        assertTrue(list.get(0) == "another meta header")
+        assertTrue(list.get(1) == "another meta item")
+        assertTrue(list.size == 2)
+    }
 }


### PR DESCRIPTION
There have been reports on [CourseListAdapter](https://console.firebase.google.com/project/opensap-firebase/crashlytics/app/android:de.xikolo.opensap/issues/a8685041fec7a7ae90e4e13ca055658b) crashes in v3.0. Somehow the data object `DateOverview` ended up being null when fetched via `MetaSectionList.get()`.
I was NOT able to reproduce the issue or find a cause, so I searched what could be the problem. It seems neither to be vendor- nor sdk- nor enrolled-courses-specific.
I found a [StackOverflow post](https://stackoverflow.com/a/30057015) about updating data inside the `RecyclerView.Adapter`. It suggests not setting the list as a new object on each update, but to update the existing list object with the new values. There could be timing, race-condition, lost-update or other similar scenarios with our current approach.
This might be a fix to it but it might as well be not. 

Could you possibly test on your (real) devices with the current production release whether the failure occurs? Else I would suggest rolling out this hotfix to the same users that are currently in the staged rollout phase and see if crashes drop.