### PR TITLE
More v3 Hotfixes

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/video/VideoDescriptionFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoDescriptionFragment.kt
@@ -5,17 +5,24 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import butterknife.BindView
+import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
 import de.xikolo.controllers.base.ViewModelFragment
 import de.xikolo.extensions.observe
 import de.xikolo.utils.extensions.setMarkdownText
 import de.xikolo.viewmodels.section.VideoDescriptionViewModel
 
-class VideoDescriptionFragment(val itemId: String, val videoId: String) : ViewModelFragment<VideoDescriptionViewModel>() {
+class VideoDescriptionFragment : ViewModelFragment<VideoDescriptionViewModel>() {
 
     companion object {
         val TAG: String = VideoDescriptionFragment::class.java.simpleName
     }
+
+    @AutoBundleField
+    lateinit var itemId: String
+
+    @AutoBundleField
+    lateinit var videoId: String
 
     @BindView(R.id.textTitle)
     lateinit var videoTitleText: TextView

--- a/app/src/main/java/de/xikolo/controllers/video/VideoItemPlayerActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoItemPlayerActivity.kt
@@ -48,7 +48,7 @@ class VideoItemPlayerActivity : BaseVideoPlayerActivity() {
     override val layoutResource = R.layout.activity_video_dual
 
     override fun createPlayerFragment(): VideoStreamPlayerFragment {
-        return VideoItemPlayerFragment(courseId, sectionId, itemId, videoId)
+        return VideoItemPlayerFragmentAutoBundle.builder(courseId, sectionId, itemId, videoId).build()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -58,7 +58,7 @@ class VideoItemPlayerActivity : BaseVideoPlayerActivity() {
     }
 
     private fun updateDescriptionFragment() {
-        descriptionFragment = VideoDescriptionFragment(itemId, videoId)
+        descriptionFragment = VideoDescriptionFragmentAutoBundle.builder(itemId, videoId).build()
 
         val fragmentTag = descriptionFragment.hashCode().toString()
         val fragmentManager = supportFragmentManager
@@ -89,9 +89,7 @@ class VideoItemPlayerActivity : BaseVideoPlayerActivity() {
                 "cast"
             )
 
-            VideoDao.Unmanaged.find(videoId)?.let {
-                it.cast(this, true)
-            }
+            VideoDao.Unmanaged.find(videoId)?.cast(this, true)
 
             finish()
         }

--- a/app/src/main/java/de/xikolo/controllers/video/VideoStreamPlayerActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoStreamPlayerActivity.kt
@@ -25,7 +25,7 @@ class VideoStreamPlayerActivity : BaseVideoPlayerActivity(), VideoStreamPlayerFr
     override val layoutResource = R.layout.activity_video
 
     override fun createPlayerFragment(): VideoStreamPlayerFragment {
-        return VideoStreamPlayerFragment(videoStream)
+        return VideoStreamPlayerFragmentAutoBundle.builder(videoStream).build()
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/app/src/main/java/de/xikolo/controllers/video/VideoStreamPlayerFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoStreamPlayerFragment.kt
@@ -14,6 +14,7 @@ import butterknife.BindView
 import com.github.rubensousa.previewseekbar.PreviewSeekBar
 import com.github.rubensousa.previewseekbar.PreviewView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.yatatsu.autobundle.AutoBundleField
 import de.xikolo.R
 import de.xikolo.config.Config
 import de.xikolo.config.FeatureConfig
@@ -30,8 +31,11 @@ import de.xikolo.views.CustomSizeVideoView
 import de.xikolo.views.ExoPlayerVideoView
 import java.util.*
 import java.util.concurrent.TimeUnit
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
 
-open class VideoStreamPlayerFragment(private var videoStream: VideoStream, private var autoPlay: Boolean? = true) : BaseFragment() {
+open class VideoStreamPlayerFragment : BaseFragment() {
 
     companion object {
         val TAG: String = VideoStreamPlayerFragment::class.java.simpleName
@@ -47,6 +51,15 @@ open class VideoStreamPlayerFragment(private var videoStream: VideoStream, priva
 
         private const val VIDEO_STEPPING_DURATION = 10000
     }
+
+    @AutoBundleField
+    lateinit var stream: VideoStream
+
+    open val videoStream: VideoStream
+        get() = stream
+
+    @AutoBundleField(required = false)
+    var autoPlay: Boolean = true
 
     @BindView(R.id.playerView)
     lateinit var playerView: CustomSizeVideoView
@@ -113,7 +126,7 @@ open class VideoStreamPlayerFragment(private var videoStream: VideoStream, priva
     private val seekBarPreviewHandler: Handler
 
     protected var initialVideoPosition: Int = 0
-    private var initialPlaybackState: Boolean = autoPlay ?: true
+    private var initialPlaybackState: Boolean = autoPlay
     private var isInitialPreparing = true
 
     private lateinit var controlsVisibilityHandler: ControlsVisibilityHandler
@@ -144,7 +157,7 @@ open class VideoStreamPlayerFragment(private var videoStream: VideoStream, priva
         get() = if (isOfflineVideo) "offline" else "online"
 
     val currentQualityString: String
-        get() = videoSettingsHelper.currentQuality.name.toLowerCase()
+        get() = videoSettingsHelper.currentQuality.name.toLowerCase(Locale.ENGLISH)
 
     var isShowingControls: Boolean = false
         private set
@@ -312,7 +325,7 @@ open class VideoStreamPlayerFragment(private var videoStream: VideoStream, priva
             private var lastPosition: Long = -1
 
             override fun loadPreview(currentPosition: Long, max: Long) {
-                if (System.currentTimeMillis() - lastPreview > SEEKBAR_PREVIEW_INTERVAL && (lastPosition < 0 || Math.abs(currentPosition - lastPosition) > SEEKBAR_PREVIEW_POSITION_DIFFERENCE)) {
+                if (System.currentTimeMillis() - lastPreview > SEEKBAR_PREVIEW_INTERVAL && (lastPosition < 0 || abs(currentPosition - lastPosition) > SEEKBAR_PREVIEW_POSITION_DIFFERENCE)) {
                     seekBarPreviewHandler.removeCallbacksAndMessages(null)
                     seekBarPreviewHandler.postAtFrontOfQueue {
                         val frame = playerView.getFrameAt(currentPosition)
@@ -378,7 +391,7 @@ open class VideoStreamPlayerFragment(private var videoStream: VideoStream, priva
         showProgress()
         setupVideo()
         updateVideo()
-        if (autoPlay == true) {
+        if (autoPlay) {
             playerView.start()
         }
         prepare()
@@ -495,7 +508,7 @@ open class VideoStreamPlayerFragment(private var videoStream: VideoStream, priva
         }
 
         return when {
-            context.isOnline                                                 -> { // device has internet connection
+            context.isOnline                                                       -> { // device has internet connection
                 if (isHls) {
                     setHlsVideoUri(stream)
                 } else {
@@ -562,7 +575,7 @@ open class VideoStreamPlayerFragment(private var videoStream: VideoStream, priva
 
     private fun stepForward() {
         seekTo(
-            Math.min(
+            min(
                 currentPosition + VIDEO_STEPPING_DURATION,
                 duration
             ),
@@ -572,7 +585,7 @@ open class VideoStreamPlayerFragment(private var videoStream: VideoStream, priva
 
     private fun stepBackward() {
         seekTo(
-            Math.max(
+            max(
                 currentPosition - VIDEO_STEPPING_DURATION,
                 0
             ),

--- a/app/src/main/java/de/xikolo/utils/extensions/StorageExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/StorageExtensions.kt
@@ -12,7 +12,9 @@ val <T : Context> T.storages: Array<Storage>
     get() {
         val storageList = mutableListOf<Storage>()
         ContextCompat.getExternalFilesDirs(this, null).forEach {
-            storageList.add(Storage(it))
+            if (it != null) {
+                storageList.add(Storage(it))
+            }
         }
         return storageList.toTypedArray()
     }


### PR DESCRIPTION
Some more critical bugfixes related to the v3.0 update.

1. Fix for `ContextCompat.getExternalFilesDirs(...)` returning Files that are `null`.
A simple null-check has been introduced.

2. Fix for `VideoStreamPlayerFragment` and `VideoItemPlayerFragment` not being able to be started from a saved instance state.
I made the mistake of using parameters in a Fragment constructor rather than AutoBundle fields. When a Fragment starts up normally this is no problem but when one is brought back to life from a `savedInstanceState`, the framework searches for the default no-argument constructor (which does not exists) and tries to recreate the instance (which is not possible as there is no `Bundle` to be recreated from, other than with AutoBundle).
I removed the constructors and added the specific Autobundle fields. Because the Fragments inherit from each other, I had to make adjustments when it comes to fields that now need a getter as their values are uninitialized after class initialization, as AutoBundle binds "late" in `onCreate`.

3. Fix for Video Fragments crashing when being prepared.
When calling `prepare()` on our `ExoPlayerVideoView`, the player loads the `MediaSource` previously set by `setVideoUri()`. `setVideoUri()` is invoked from `VideoStreamPlayerFragment`'s `setVideoUri()` which itself is called from `updateVideo()`. `updateVideo()` is always called before `prepare()`. But because `updateVideo()` ignored the returning success boolean from `setVideoUri()`, I suppose it was possible that no video and thus no media source was set prior to calling `prepare()` when an error occured during `setVideoUri()`, which resulted in the crash.
To fix that I made `updateVideo()` handle the returning boolean from `setVideoUri()` and return a boolean itself. Only if this value is `true`, a video uri was set successfully and preparation can start.

#191 solved the problems and no more crashes occur. These fixes solve the most prominent crash causes until now.