### PR TITLE
Fix crash when in PiP

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/video/base/BaseVideoPlayerActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/video/base/BaseVideoPlayerActivity.kt
@@ -85,7 +85,7 @@ abstract class BaseVideoPlayerActivity : BaseActivity(), VideoStreamPlayerFragme
         if (fragmentManager.findFragmentByTag(fragmentTag) == null) {
             val transaction = fragmentManager.beginTransaction()
             transaction.replace(R.id.videoPlayerFragment, playerFragment, fragmentTag)
-            transaction.commit()
+            transaction.commitNow()
         }
     }
 
@@ -219,7 +219,6 @@ abstract class BaseVideoPlayerActivity : BaseActivity(), VideoStreamPlayerFragme
             registerReceiver(pipControlsBroadcastReceiver, IntentFilter(ACTION_SWITCH_PLAYBACK_STATE))
         } else {
             updateVideoView()
-            playerFragment.showControls()
 
             try {
                 unregisterReceiver(pipControlsBroadcastReceiver)


### PR DESCRIPTION
Fixes a bug that caused a crash when a video was played in picture-in-picture mode and playback for another video was started.

When a new video is played, the `onNewIntent` of the Activity is invoked. This leads to the construction of a new player Fragment. This new Fragment is committed via `commit()`. The following tasks included checking whether immersive mode is available by checking the aspect ratio of the player view. But because the Fragment was not yet initialized, this process failed. `commitNow()` solves this by executing the transaction immediately, effectively synchronizing the lifecycle of Activity and Fragment.