### PR TITLE
channel teaser video implemented

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/base/CollapsingToolbarViewModelActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/base/CollapsingToolbarViewModelActivity.kt
@@ -8,8 +8,6 @@ import butterknife.BindView
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import de.xikolo.R
-import de.xikolo.R.id.appbar
-import de.xikolo.R.id.collapsing_toolbar
 import de.xikolo.viewmodels.base.BaseViewModel
 
 abstract class CollapsingToolbarViewModelActivity<T : BaseViewModel> : ViewModelActivity<T>() {
@@ -21,10 +19,10 @@ abstract class CollapsingToolbarViewModelActivity<T : BaseViewModel> : ViewModel
     @BindView(R.id.toolbar_image)
     lateinit var imageView: ImageView
 
-    @BindView(appbar)
+    @BindView(R.id.appbar)
     lateinit var appBarLayout: AppBarLayout
 
-    @BindView(collapsing_toolbar)
+    @BindView(R.id.collapsing_toolbar)
     protected lateinit var collapsingToolbar: CollapsingToolbarLayout
 
     @BindView(R.id.scrim_top)
@@ -47,13 +45,9 @@ abstract class CollapsingToolbarViewModelActivity<T : BaseViewModel> : ViewModel
         lp.height = actionBarHeight + statusBarHeight
 
         collapsingToolbar.isTitleEnabled = false
-
-        if (toolbar != null) {
-            toolbar!!.title = title
-        }
+        toolbar?.title = title
 
         scrimTop.visibility = View.INVISIBLE
-
         scrimBottom.visibility = View.INVISIBLE
     }
 
@@ -70,7 +64,8 @@ abstract class CollapsingToolbarViewModelActivity<T : BaseViewModel> : ViewModel
     private val actionBarHeight: Int
         get() {
             val styledAttributes = theme.obtainStyledAttributes(
-                intArrayOf(android.R.attr.actionBarSize))
+                intArrayOf(android.R.attr.actionBarSize)
+            )
             val result = styledAttributes.getDimension(0, 0f).toInt()
             styledAttributes.recycle()
             return result

--- a/app/src/main/java/de/xikolo/controllers/base/CollapsingToolbarViewModelActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/base/CollapsingToolbarViewModelActivity.kt
@@ -49,7 +49,7 @@ abstract class CollapsingToolbarViewModelActivity<T : BaseViewModel> : ViewModel
         collapsingToolbar.isTitleEnabled = false
 
         if (toolbar != null) {
-            toolbar.title = title
+            toolbar!!.title = title
         }
 
         scrimTop.visibility = View.INVISIBLE

--- a/app/src/main/java/de/xikolo/controllers/base/CollapsingToolbarViewModelActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/base/CollapsingToolbarViewModelActivity.kt
@@ -1,0 +1,79 @@
+package de.xikolo.controllers.base
+
+import android.os.Bundle
+import android.view.View
+import android.widget.ImageView
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import butterknife.BindView
+import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.appbar.CollapsingToolbarLayout
+import de.xikolo.R
+import de.xikolo.R.id.appbar
+import de.xikolo.R.id.collapsing_toolbar
+import de.xikolo.viewmodels.base.BaseViewModel
+
+abstract class CollapsingToolbarViewModelActivity<T : BaseViewModel> : ViewModelActivity<T>() {
+
+    companion object {
+        val TAG: String = CollapsingToolbarViewModelActivity::class.java.simpleName
+    }
+
+    @BindView(R.id.toolbar_image)
+    lateinit var imageView: ImageView
+
+    @BindView(appbar)
+    lateinit var appBarLayout: AppBarLayout
+
+    @BindView(collapsing_toolbar)
+    protected lateinit var collapsingToolbar: CollapsingToolbarLayout
+
+    @BindView(R.id.scrim_top)
+    lateinit var scrimTop: View
+
+    @BindView(R.id.scrim_bottom)
+    lateinit var scrimBottom: View
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.activity_blank_collapsing)
+        setupActionBar(true)
+        enableOfflineModeToolbar(false)
+    }
+
+    protected fun lockCollapsingToolbar(title: String) {
+        appBarLayout.setExpanded(false, false)
+        val lp = appBarLayout.layoutParams as CoordinatorLayout.LayoutParams
+        lp.height = actionBarHeight + statusBarHeight
+
+        collapsingToolbar.isTitleEnabled = false
+
+        if (toolbar != null) {
+            toolbar.title = title
+        }
+
+        scrimTop.visibility = View.INVISIBLE
+
+        scrimBottom.visibility = View.INVISIBLE
+    }
+
+    private val statusBarHeight: Int
+        get() {
+            var result = 0
+            val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
+            if (resourceId > 0) {
+                result = application.resources.getDimensionPixelSize(resourceId)
+            }
+            return result
+        }
+
+    private val actionBarHeight: Int
+        get() {
+            val styledAttributes = theme.obtainStyledAttributes(
+                intArrayOf(android.R.attr.actionBarSize))
+            val result = styledAttributes.getDimension(0, 0f).toInt()
+            styledAttributes.recycle()
+            return result
+        }
+
+}

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelCourseListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelCourseListAdapter.kt
@@ -24,7 +24,7 @@ import de.xikolo.utils.extensions.videoThumbnailSize
 import de.xikolo.views.CustomSizeImageView
 import java.util.*
 
-class ChannelCourseListAdapter(fragment: Fragment, onCourseButtonClickListener: OnCourseButtonClickListener) : BaseCourseListAdapter<Pair<String?, VideoStream?>>(fragment, onCourseButtonClickListener) {
+class ChannelCourseListAdapter(fragment: Fragment, onCourseButtonClickListener: OnCourseButtonClickListener) : BaseCourseListAdapter<Triple<String?, VideoStream?, String?>>(fragment, onCourseButtonClickListener) {
 
     companion object {
         val TAG: String = ChannelCourseListAdapter::class.java.simpleName
@@ -48,9 +48,10 @@ class ChannelCourseListAdapter(fragment: Fragment, onCourseButtonClickListener: 
         when (holder) {
             is HeaderViewHolder      -> bindHeaderViewHolder(holder, position)
             is DescriptionViewHolder -> {
-                val meta = super.contentList.get(position) as Pair<*, *>?
+                val meta = super.contentList.get(position) as Triple<*, *, *>?
                 val description = meta?.first as String?
                 val stageStream = meta?.second as VideoStream?
+                val imageUrl = meta?.third as String?
 
                 if (description != null) {
                     holder.text.setMarkdownText(description)
@@ -61,9 +62,9 @@ class ChannelCourseListAdapter(fragment: Fragment, onCourseButtonClickListener: 
                 if (stageStream?.hdUrl != null || stageStream?.sdUrl != null) {
                     holder.videoPreview.visibility = View.VISIBLE
 
-                    if (stageStream.thumbnailUrl != null) {
+                    if (imageUrl != null) {
                         GlideApp.with(fragment)
-                            .load(stageStream.thumbnailUrl)
+                            .load(imageUrl)
                             .override(holder.imageVideoThumbnail.forcedWidth, holder.imageVideoThumbnail.forcedHeight)
                             .into(holder.imageVideoThumbnail)
                     }

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelCourseListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelCourseListAdapter.kt
@@ -72,22 +72,22 @@ class ChannelCourseListAdapter(fragment: Fragment, onCourseButtonClickListener: 
                         val thumbnailSize: Point = it.videoThumbnailSize
                         holder.imageVideoThumbnail.setDimensions(thumbnailSize.x, thumbnailSize.y)
                     }
+
+                    holder.playButton.setOnClickListener {
+                        fragment.activity?.let { activity ->
+                            activity.startActivity(
+                                VideoStreamPlayerActivityAutoBundle.builder(stageStream)
+                                    .parentIntent(activity.intent)
+                                    .overrideActualParent(true)
+                                    .build(activity)
+                            )
+                        }
+                    }
                 } else {
                     holder.videoPreview.visibility = View.GONE
                 }
 
                 holder.durationText.visibility = View.GONE
-
-                holder.playButton.setOnClickListener {
-                    fragment.activity?.let { activity ->
-                        activity.startActivity(
-                            VideoStreamPlayerActivityAutoBundle.builder(meta?.second as VideoStream)
-                                .parentIntent(activity.intent)
-                                .overrideActualParent(true)
-                                .build(activity)
-                        )
-                    }
-                }
             }
             is CourseViewHolder      -> {
                 val course = super.contentList.get(position) as Course

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelCourseListAdapter.kt
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelCourseListAdapter.kt
@@ -1,5 +1,6 @@
 package de.xikolo.controllers.channels
 
+import android.graphics.Point
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,13 +13,18 @@ import butterknife.BindView
 import butterknife.ButterKnife
 import de.xikolo.App
 import de.xikolo.R
+import de.xikolo.config.GlideApp
 import de.xikolo.controllers.base.BaseCourseListAdapter
+import de.xikolo.controllers.video.VideoStreamPlayerActivityAutoBundle
 import de.xikolo.models.Course
+import de.xikolo.models.VideoStream
 import de.xikolo.utils.extensions.isBetween
 import de.xikolo.utils.extensions.setMarkdownText
+import de.xikolo.utils.extensions.videoThumbnailSize
+import de.xikolo.views.CustomSizeImageView
 import java.util.*
 
-class ChannelCourseListAdapter(fragment: Fragment, onCourseButtonClickListener: OnCourseButtonClickListener) : BaseCourseListAdapter<String>(fragment, onCourseButtonClickListener) {
+class ChannelCourseListAdapter(fragment: Fragment, onCourseButtonClickListener: OnCourseButtonClickListener) : BaseCourseListAdapter<Pair<String, VideoStream?>>(fragment, onCourseButtonClickListener) {
 
     companion object {
         val TAG: String = ChannelCourseListAdapter::class.java.simpleName
@@ -42,12 +48,43 @@ class ChannelCourseListAdapter(fragment: Fragment, onCourseButtonClickListener: 
         when (holder) {
             is HeaderViewHolder      -> bindHeaderViewHolder(holder, position)
             is DescriptionViewHolder -> {
-                val description = super.contentList.get(position) as String?
+                val meta = super.contentList.get(position) as Pair<String, VideoStream?>?
+                val description = meta?.first
                 if (description != null) {
                     holder.text.setMarkdownText(description)
                 } else {
                     holder.text.visibility = View.GONE
                 }
+
+                if (meta?.second == null) {
+                    holder.videoPreview.visibility = View.GONE
+                } else {
+                    holder.durationText.visibility = View.GONE
+                }
+
+                holder.playButton.setOnClickListener {
+                    fragment.activity?.let { activity ->
+                        activity.startActivity(
+                            VideoStreamPlayerActivityAutoBundle.builder(meta?.second as VideoStream)
+                                .parentIntent(activity.intent)
+                                .overrideActualParent(true)
+                                .build(activity)
+                        )
+                    }
+                }
+
+                if (meta?.second != null && meta.second?.thumbnailUrl != null) {
+                    GlideApp.with(fragment)
+                        .load(meta.second?.thumbnailUrl)
+                        .override(holder.imageVideoThumbnail.forcedWidth, holder.imageVideoThumbnail.forcedHeight)
+                        .into(holder.imageVideoThumbnail)
+                }
+
+                fragment.activity?.let {
+                    val thumbnailSize: Point = it.videoThumbnailSize
+                    holder.imageVideoThumbnail.setDimensions(thumbnailSize.x, thumbnailSize.y)
+                }
+
             }
             is CourseViewHolder      -> {
                 val course = super.contentList.get(position) as Course
@@ -81,6 +118,18 @@ class ChannelCourseListAdapter(fragment: Fragment, onCourseButtonClickListener: 
 
         @BindView(R.id.text)
         lateinit var text: TextView
+
+        @BindView(R.id.videoPreview)
+        lateinit var videoPreview: ViewGroup
+
+        @BindView(R.id.playButton)
+        lateinit var playButton: View
+
+        @BindView(R.id.videoThumbnail)
+        lateinit var imageVideoThumbnail: CustomSizeImageView
+
+        @BindView(R.id.durationText)
+        lateinit var durationText: TextView
 
         init {
             ButterKnife.bind(this, view)

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsActivity.kt
@@ -39,7 +39,9 @@ class ChannelDetailsActivity : CollapsingToolbarActivity() {
 
             val tag = "content"
 
-            if (channel.imageUrl != null) {
+            if (channel.stageStream != null) {
+                lockCollapsingToolbar(channel.title)
+            } else if (channel.imageUrl != null) {
                 GlideApp.with(this).load(channel.imageUrl).into(imageView)
             } else {
                 lockCollapsingToolbar(channel.title)

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
@@ -22,6 +22,7 @@ import de.xikolo.extensions.observeOnce
 import de.xikolo.managers.UserManager
 import de.xikolo.models.Channel
 import de.xikolo.models.Course
+import de.xikolo.models.VideoStream
 import de.xikolo.models.dao.CourseDao
 import de.xikolo.network.jobs.base.NetworkCode
 import de.xikolo.network.jobs.base.NetworkStateLiveData
@@ -132,16 +133,23 @@ class ChannelDetailsFragment : ViewModelFragment<ChannelViewModel>() {
 
     private fun updateView(channel: Channel) {
         if (activity is ChannelDetailsActivity) {
-            layoutHeader.visibility = View.GONE
+
+            if (channel.stageStream != null) {
+                layoutHeader.visibility = View.GONE
+            } else {
+                layoutHeader.visibility = View.GONE
+            }
+
         } else {
             GlideApp.with(this).load(channel.imageUrl).into(imageChannel)
             textTitle.text = channel.title
         }
 
         contentListAdapter.setThemeColor(channel.colorOrDefault)
+        showContent()
     }
 
-    private fun showContentList(contents: MetaSectionList<String, String, List<Course>>) {
+    private fun showContentList(contents: MetaSectionList<String, Pair<String, VideoStream?>, List<Course>>) {
         contentListAdapter.update(contents)
 
         if (scrollToCoursePosition >= 0) {
@@ -216,7 +224,7 @@ class ChannelDetailsFragment : ViewModelFragment<ChannelViewModel>() {
         startActivity(intent)
     }
 
-    private fun enterExternalCourse(course: Course){
+    private fun enterExternalCourse(course: Course) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(course.externalUrl))
         startActivity(intent)
     }

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
@@ -112,19 +112,21 @@ class ChannelDetailsFragment : ViewModelFragment<ChannelViewModel>() {
 
                 override val itemCount: Int
                     get() = contentListAdapter.itemCount
-
             }
         ))
 
         viewModel.channel
             .observe(viewLifecycleOwner) {
                 updateView(it)
+                updateContentList(
+                    viewModel.buildContentList(it)
+                )
             }
 
         viewModel.courses
             .observe(viewLifecycleOwner) {
                 viewModel.channel.value?.let {
-                    showContentList(
+                    updateContentListAndScroll(
                         viewModel.buildContentList(it)
                     )
                 }
@@ -133,24 +135,23 @@ class ChannelDetailsFragment : ViewModelFragment<ChannelViewModel>() {
 
     private fun updateView(channel: Channel) {
         if (activity is ChannelDetailsActivity) {
-
-            if (channel.stageStream != null) {
-                layoutHeader.visibility = View.GONE
-            } else {
-                layoutHeader.visibility = View.GONE
-            }
-
+            layoutHeader.visibility = View.GONE
         } else {
             GlideApp.with(this).load(channel.imageUrl).into(imageChannel)
             textTitle.text = channel.title
+            layoutHeader.visibility = View.VISIBLE
         }
 
         contentListAdapter.setThemeColor(channel.colorOrDefault)
         showContent()
     }
 
-    private fun showContentList(contents: MetaSectionList<String, Pair<String, VideoStream?>, List<Course>>) {
+    private fun updateContentList(contents: MetaSectionList<String, Pair<String?, VideoStream?>, List<Course>>) {
         contentListAdapter.update(contents)
+    }
+
+    private fun updateContentListAndScroll(contents: MetaSectionList<String, Pair<String?, VideoStream?>, List<Course>>) {
+        updateContentList(contents)
 
         if (scrollToCoursePosition >= 0) {
             try {

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
@@ -146,11 +146,11 @@ class ChannelDetailsFragment : ViewModelFragment<ChannelViewModel>() {
         showContent()
     }
 
-    private fun updateContentList(contents: MetaSectionList<String, Pair<String?, VideoStream?>, List<Course>>) {
+    private fun updateContentList(contents: MetaSectionList<String, Triple<String?, VideoStream?, String?>, List<Course>>) {
         contentListAdapter.update(contents)
     }
 
-    private fun updateContentListAndScroll(contents: MetaSectionList<String, Pair<String?, VideoStream?>, List<Course>>) {
+    private fun updateContentListAndScroll(contents: MetaSectionList<String, Triple<String?, VideoStream?, String?>, List<Course>>) {
         updateContentList(contents)
 
         if (scrollToCoursePosition >= 0) {

--- a/app/src/main/java/de/xikolo/models/Channel.java
+++ b/app/src/main/java/de/xikolo/models/Channel.java
@@ -34,6 +34,8 @@ public class Channel extends RealmObject {
 
     public String imageUrl;
 
+    public VideoStream stageStream;
+
     public int getColorOrDefault() {
         if (color != null)
             try {
@@ -61,6 +63,9 @@ public class Channel extends RealmObject {
         @Json(name = "mobile_image_url")
         public String mobileImageUrl;
 
+        @Json(name = "stage_stream")
+        public VideoStream stageStream;
+
         @Override
         public Channel convertToRealmObject() {
             Channel model = new Channel();
@@ -71,6 +76,7 @@ public class Channel extends RealmObject {
             model.position = position;
             model.description = description;
             model.imageUrl = mobileImageUrl;
+            model.stageStream = stageStream;
 
             return model;
         }

--- a/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
+++ b/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
@@ -121,7 +121,7 @@ public class RealmSchemaMigration implements RealmMigration {
 
             oldVersion++;
         }
-        
+
         if (oldVersion == 8) {
             schema.get("Video")
                 .addRealmObjectField("lecturerStream", schema.get("VideoStream"))
@@ -148,5 +148,5 @@ public class RealmSchemaMigration implements RealmMigration {
             schema.get("Channel").addRealmObjectField("stageStream", schema.get("VideoStream"));
         }
     }
-    
+
 }

--- a/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
+++ b/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
@@ -126,9 +126,7 @@ public class RealmSchemaMigration implements RealmMigration {
             schema.get("Video")
                 .addRealmObjectField("lecturerStream", schema.get("VideoStream"))
                 .addRealmObjectField("slidesStream", schema.get("VideoStream"));
-                
-            schema.get("Channel").addRealmObjectField("stageStream", schema.get("VideoStream"));
-            
+
             oldVersion++;
         }
 
@@ -145,6 +143,9 @@ public class RealmSchemaMigration implements RealmMigration {
 
             oldVersion++;
         }
-    }
 
+        if (oldVersion == 10) {
+            schema.get("Channel").addRealmObjectField("stageStream", schema.get("VideoStream"));
+        }
+    }
 }

--- a/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
+++ b/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
@@ -121,12 +121,14 @@ public class RealmSchemaMigration implements RealmMigration {
 
             oldVersion++;
         }
-
+        
         if (oldVersion == 8) {
             schema.get("Video")
                 .addRealmObjectField("lecturerStream", schema.get("VideoStream"))
                 .addRealmObjectField("slidesStream", schema.get("VideoStream"));
-
+                
+            schema.get("Channel").addRealmObjectField("stageStream", schema.get("VideoStream"));
+            
             oldVersion++;
         }
 

--- a/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
+++ b/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
@@ -148,4 +148,5 @@ public class RealmSchemaMigration implements RealmMigration {
             schema.get("Channel").addRealmObjectField("stageStream", schema.get("VideoStream"));
         }
     }
+    
 }

--- a/app/src/main/java/de/xikolo/viewmodels/channel/ChannelViewModel.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/channel/ChannelViewModel.kt
@@ -30,8 +30,8 @@ class ChannelViewModel(private val channelId: String) : BaseViewModel() {
 
     val courses = courseListDelegate.courses
 
-    fun buildContentList(channel: Channel): MetaSectionList<String, Pair<String, VideoStream?>, List<Course>> {
-        val contentList = MetaSectionList<String, Pair<String, VideoStream?>, List<Course>>(Pair<String, VideoStream?>(channel.description, channel.stageStream))
+    fun buildContentList(channel: Channel): MetaSectionList<String, Pair<String?, VideoStream?>, List<Course>> {
+        val contentList = MetaSectionList<String, Pair<String?, VideoStream?>, List<Course>>(Pair<String?, VideoStream?>(channel.description, channel.stageStream))
         var subList: List<Course>
         if (BuildConfig.X_FLAVOR == BuildFlavor.OPEN_WHO) {
             subList = CourseDao.Unmanaged.allFutureForChannel(channelId)

--- a/app/src/main/java/de/xikolo/viewmodels/channel/ChannelViewModel.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/channel/ChannelViewModel.kt
@@ -7,6 +7,7 @@ import de.xikolo.R
 import de.xikolo.config.BuildFlavor
 import de.xikolo.models.Channel
 import de.xikolo.models.Course
+import de.xikolo.models.VideoStream
 import de.xikolo.models.dao.ChannelDao
 import de.xikolo.models.dao.CourseDao
 import de.xikolo.network.jobs.GetChannelWithCoursesJob
@@ -29,8 +30,8 @@ class ChannelViewModel(private val channelId: String) : BaseViewModel() {
 
     val courses = courseListDelegate.courses
 
-    fun buildContentList(channel: Channel): MetaSectionList<String, String, List<Course>> {
-        val contentList = MetaSectionList<String, String, List<Course>>(channel.description)
+    fun buildContentList(channel: Channel): MetaSectionList<String, Pair<String, VideoStream?>, List<Course>> {
+        val contentList = MetaSectionList<String, Pair<String, VideoStream?>, List<Course>>(Pair<String, VideoStream?>(channel.description, channel.stageStream))
         var subList: List<Course>
         if (BuildConfig.X_FLAVOR == BuildFlavor.OPEN_WHO) {
             subList = CourseDao.Unmanaged.allFutureForChannel(channelId)

--- a/app/src/main/java/de/xikolo/viewmodels/channel/ChannelViewModel.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/channel/ChannelViewModel.kt
@@ -30,8 +30,8 @@ class ChannelViewModel(private val channelId: String) : BaseViewModel() {
 
     val courses = courseListDelegate.courses
 
-    fun buildContentList(channel: Channel): MetaSectionList<String, Pair<String?, VideoStream?>, List<Course>> {
-        val contentList = MetaSectionList<String, Pair<String?, VideoStream?>, List<Course>>(Pair<String?, VideoStream?>(channel.description, channel.stageStream))
+    fun buildContentList(channel: Channel): MetaSectionList<String, Triple<String?, VideoStream?, String?>, List<Course>> {
+        val contentList = MetaSectionList<String, Triple<String?, VideoStream?, String?>, List<Course>>(Triple<String?, VideoStream?, String>(channel.description, channel.stageStream, channel.imageUrl))
         var subList: List<Course>
         if (BuildConfig.X_FLAVOR == BuildFlavor.OPEN_WHO) {
             subList = CourseDao.Unmanaged.allFutureForChannel(channelId)

--- a/app/src/main/res/layout/content_channel_description.xml
+++ b/app/src/main/res/layout/content_channel_description.xml
@@ -3,15 +3,14 @@
     android:id="@+id/linearLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:layout_marginLeft="-6dp"
+    android:layout_marginRight="-6dp"
+    android:orientation="vertical"><!-- -6dp margin is workaround to remove parent RecyclerView padding -->
 
-    <!-- -6dp margin is workaround to remove parent RecyclerView padding -->
     <include
         layout="@layout/container_video_preview"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="-6dp"
-        android:layout_marginRight="-6dp" />
+        android:layout_height="wrap_content" />
 
     <TextView
         android:id="@+id/text"

--- a/app/src/main/res/layout/content_channel_description.xml
+++ b/app/src/main/res/layout/content_channel_description.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/linearLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <include
+        layout="@layout/container_video_preview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
     <TextView
         android:id="@+id/text"
@@ -16,4 +23,4 @@
         android:textColorLink="@color/apptheme_second"
         android:textSize="14sp" />
 
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/content_channel_description.xml
+++ b/app/src/main/res/layout/content_channel_description.xml
@@ -5,10 +5,13 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
+    <!-- -6dp margin is workaround to remove parent RecyclerView padding -->
     <include
         layout="@layout/container_video_preview"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="-6dp"
+        android:layout_marginRight="-6dp" />
 
     <TextView
         android:id="@+id/text"

--- a/app/src/main/res/layout/content_channel_description.xml
+++ b/app/src/main/res/layout/content_channel_description.xml
@@ -3,8 +3,8 @@
     android:id="@+id/linearLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="-6dp"
-    android:layout_marginRight="-6dp"
+    android:layout_marginLeft="@dimen/channel_channel_details_margin"
+    android:layout_marginRight="@dimen/channel_channel_details_margin"
     android:orientation="vertical"><!-- -6dp margin is workaround to remove parent RecyclerView padding -->
 
     <include
@@ -19,7 +19,7 @@
         android:layout_marginLeft="@dimen/channel_course_list_description_margin"
         android:layout_marginTop="16dp"
         android:layout_marginRight="@dimen/channel_course_list_description_margin"
-        android:layout_marginBottom="16dp"
+        android:layout_marginBottom="8dp"
         android:lineSpacingExtra="4dp"
         android:textColor="@color/text_main"
         android:textColorLink="@color/apptheme_second"

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -3,7 +3,7 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
 
-    <dimen name="channel_course_list_description_margin">4dp</dimen>
+    <dimen name="channel_course_list_description_margin">6dp</dimen>
 
     <dimen name="content_horizontal_margin">20dp</dimen>
 

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -3,7 +3,8 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
 
-    <dimen name="channel_course_list_description_margin">6dp</dimen>
+    <dimen name="channel_channel_details_margin">-16dp</dimen>
+    <dimen name="channel_course_list_description_margin">20dp</dimen>
 
     <dimen name="content_horizontal_margin">20dp</dimen>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,7 +3,8 @@
     <dimen name="activity_horizontal_margin">6dp</dimen>
     <dimen name="activity_vertical_margin">6dp</dimen>
 
-    <dimen name="channel_course_list_description_margin">12dp</dimen>
+    <dimen name="channel_channel_details_margin">-6dp</dimen>
+    <dimen name="channel_course_list_description_margin">10dp</dimen>
 
     <dimen name="collapsing_toolbar_height">288dp</dimen>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,7 +3,7 @@
     <dimen name="activity_horizontal_margin">6dp</dimen>
     <dimen name="activity_vertical_margin">6dp</dimen>
 
-    <dimen name="channel_course_list_description_margin">10dp</dimen>
+    <dimen name="channel_course_list_description_margin">12dp</dimen>
 
     <dimen name="collapsing_toolbar_height">288dp</dimen>
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         versionCode         = 50
 
         xikoloApiVersion    = 3
-        realmSchemaVersion  = 10
+        realmSchemaVersion  = 11
     }
     repositories {
         jcenter()


### PR DESCRIPTION
This is a first solution for the Channel Teaser Video Issue #190 

The collabsing toolbar is only shown, if there is no Channel Teaser Video. If there is one, the Video will be embedded as meta object in the Meta Section List and the collapsing toolbar is locked. 

~Currently there ist still one major bug:~

~When the ChannelDetailsFragment is opened and one clicks on the channel, the Video is not shown. It is as if there was no test for the stageStream, so the collapsing toolbar is shown. When you reopen the channel the video is shown. Unfortunately the same problem appears when you dont have a teaser video, so a Channel without a stageStream would still lock the toolbar and show the Video Layout. I (and Ben) have not been able to find a solution for that.~

Furthermore I'm looking forward to UI feedback. Here is what it looks like:

You see **two play buttons**, because openSAP embedded a play button on the thumbnail.

<img src="https://user-images.githubusercontent.com/38314662/70986650-9c841b80-20be-11ea-9977-35ac9f88336c.png" width="200px"/> <img src="https://user-images.githubusercontent.com/38314662/70986652-9c841b80-20be-11ea-8532-a079637c0bc9.png" width="200px"/> <img src="https://user-images.githubusercontent.com/38314662/70986653-9d1cb200-20be-11ea-8a4c-bf43bbdd94e8.png" width="200px"/> 



