### PR TITLE
Fix for blank screen in CourseItemsActivity upon rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -154,8 +154,7 @@
         <activity
             android:name=".controllers.section.CourseItemsActivity"
             android:launchMode="singleTop"
-            android:parentActivityName=".controllers.course.CourseActivity"
-            android:configChanges="keyboardHidden|screenSize|orientation"><!-- workaround fix for disappearing fragments on rotation -->
+            android:parentActivityName=".controllers.course.CourseActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".controllers.course.CourseActivity" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -154,7 +154,8 @@
         <activity
             android:name=".controllers.section.CourseItemsActivity"
             android:launchMode="singleTop"
-            android:parentActivityName=".controllers.course.CourseActivity">
+            android:parentActivityName=".controllers.course.CourseActivity"
+            android:configChanges="keyboardHidden|screenSize|orientation"><!-- workaround fix for disappearing fragments on rotation -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".controllers.course.CourseActivity" />

--- a/app/src/main/java/de/xikolo/controllers/section/CourseItemsActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/CourseItemsActivity.kt
@@ -84,8 +84,6 @@ class CourseItemsActivity : ViewModelActivity<CourseItemsViewModel>() {
 
                 updateViewPager(it.accessibleItems)
             }
-
-        updateViewPager(listOf())
     }
 
     private fun updateViewPager(itemList: List<Item>) {


### PR DESCRIPTION
I believe this is caused by our messy handling of the fragment adapter (which I do not want to touch again), but this workaround fix works as well.