### PR TITLE
Fix for video singleStream null crash

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
@@ -117,7 +117,7 @@ class VideoPreviewFragment : ViewModelFragment<VideoPreviewViewModel>() {
         downloadViewHelpers.clear()
 
         activity?.let { activity ->
-            if (video.singleStream.hdUrl != null) {
+            if (video.streamToPlay.hdUrl != null) {
                 val dvh = DownloadViewHelper(
                     activity,
                     DownloadAsset.Course.Item.VideoHD(item, video),
@@ -128,7 +128,7 @@ class VideoPreviewFragment : ViewModelFragment<VideoPreviewViewModel>() {
                 downloadViewHelpers.add(dvh)
             }
 
-            if (video.singleStream.sdUrl != null) {
+            if (video.streamToPlay.sdUrl != null) {
                 val dvh = DownloadViewHelper(
                     activity,
                     DownloadAsset.Course.Item.VideoSD(item, video),

--- a/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
@@ -117,7 +117,7 @@ class VideoPreviewFragment : ViewModelFragment<VideoPreviewViewModel>() {
         downloadViewHelpers.clear()
 
         activity?.let { activity ->
-            if (video.streamToPlay.hdUrl != null) {
+            if (video.streamToPlay?.hdUrl != null) {
                 val dvh = DownloadViewHelper(
                     activity,
                     DownloadAsset.Course.Item.VideoHD(item, video),
@@ -128,7 +128,7 @@ class VideoPreviewFragment : ViewModelFragment<VideoPreviewViewModel>() {
                 downloadViewHelpers.add(dvh)
             }
 
-            if (video.streamToPlay.sdUrl != null) {
+            if (video.streamToPlay?.sdUrl != null) {
                 val dvh = DownloadViewHelper(
                     activity,
                     DownloadAsset.Course.Item.VideoSD(item, video),

--- a/app/src/main/java/de/xikolo/controllers/video/VideoItemPlayerFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoItemPlayerFragment.kt
@@ -35,7 +35,7 @@ class VideoItemPlayerFragment : VideoStreamPlayerFragment() {
     lateinit var videoId: String
 
     override val videoStream: VideoStream
-        get() = video.singleStream
+        get() = video.streamToPlay
 
     private val video: Video
         get() = VideoDao.Unmanaged.find(videoId)!!

--- a/app/src/main/java/de/xikolo/models/DownloadAsset.kt
+++ b/app/src/main/java/de/xikolo/models/DownloadAsset.kt
@@ -90,10 +90,10 @@ open class DownloadAsset(val url: String?, open val fileName: String, var storag
                 override val size = video.transcriptSize.toLong()
             }
 
-            class VideoSD(item: de.xikolo.models.Item, val video: Video) : Item(video.singleStream.sdUrl, "video_sd_${item.id}.mp4", item) {
+            class VideoSD(item: de.xikolo.models.Item, val video: Video) : Item(video.streamToPlay.sdUrl, "video_sd_${item.id}.mp4", item) {
                 override val title = "Video (SD): " + item.title
                 override val mimeType = "video/mp4"
-                override val size = video.singleStream.sdSize.toLong()
+                override val size = video.streamToPlay.sdSize.toLong()
 
                 override val secondaryAssets: MutableSet<DownloadAsset>
                     get() {
@@ -108,10 +108,10 @@ open class DownloadAsset(val url: String?, open val fileName: String, var storag
                 }
             }
 
-            class VideoHD(item: de.xikolo.models.Item, val video: Video) : Item(video.singleStream.hdUrl, "video_hd_${item.id}.mp4", item) {
+            class VideoHD(item: de.xikolo.models.Item, val video: Video) : Item(video.streamToPlay.hdUrl, "video_hd_${item.id}.mp4", item) {
                 override val title = "Video (HD): " + item.title
                 override val mimeType = "video/mp4"
-                override val size = video.singleStream.hdSize.toLong()
+                override val size = video.streamToPlay.hdSize.toLong()
 
                 override val secondaryAssets: MutableSet<DownloadAsset>
                     get() {

--- a/app/src/main/java/de/xikolo/models/Video.java
+++ b/app/src/main/java/de/xikolo/models/Video.java
@@ -24,6 +24,10 @@ public class Video extends RealmObject {
 
     public VideoStream singleStream;
 
+    public VideoStream lecturerStream;
+
+    public VideoStream slidesStream;
+
     public String slidesUrl;
 
     public int slidesSize;
@@ -43,6 +47,18 @@ public class Video extends RealmObject {
     // local field
     public int progress = 0;
 
+    public VideoStream getStreamToPlay() {
+        if (singleStream != null && (singleStream.hdUrl != null || singleStream.sdUrl != null)) {
+            return singleStream;
+        }
+
+        if (lecturerStream != null && (lecturerStream.hdUrl != null || lecturerStream.sdUrl != null)) {
+            return lecturerStream;
+        }
+
+        return slidesStream;
+    }
+
     @JsonApi(type = "videos")
     public static class JsonModel extends Resource implements RealmAdapter<Video> {
 
@@ -54,6 +70,12 @@ public class Video extends RealmObject {
 
         @Json(name = "single_stream")
         public VideoStream singleStream;
+
+        @Json(name = "lecturer_stream")
+        public VideoStream lecturerStream;
+
+        @Json(name = "slides_stream")
+        public VideoStream slidesStream;
 
         @Json(name = "slides_url")
         public String slidesUrl;
@@ -86,6 +108,8 @@ public class Video extends RealmObject {
             video.summary = summary;
             video.duration = duration;
             video.singleStream = singleStream;
+            video.lecturerStream = lecturerStream;
+            video.slidesStream = slidesStream;
             video.slidesUrl = slidesUrl;
             video.slidesSize = slidesSize;
             video.audioUrl = audioUrl;

--- a/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
+++ b/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
@@ -121,6 +121,14 @@ public class RealmSchemaMigration implements RealmMigration {
 
             oldVersion++;
         }
+
+        if (oldVersion == 8) {
+            schema.get("Video")
+                .addRealmObjectField("lecturerStream", schema.get("VideoStream"))
+                .addRealmObjectField("slidesStream", schema.get("VideoStream"));
+
+            oldVersion++;
+        }
     }
 
 }

--- a/app/src/main/java/de/xikolo/utils/extensions/CastExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/CastExtensions.kt
@@ -99,7 +99,7 @@ fun <T : Video> T.cast(activity: Activity, autoPlay: Boolean): PendingResult<Rem
         // large image, used on the Cast Player page and Lock Screen on KitKat
         mediaMetadata.addImage(image)
 
-        val castMetadata = MediaInfo.Builder(singleStream.hdUrl)
+        val castMetadata = MediaInfo.Builder(streamToPlay.hdUrl)
             .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
             .setContentType("videos/mp4")
             .setMetadata(mediaMetadata)

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         versionCode         = 50
 
         xikoloApiVersion    = 3
-        realmSchemaVersion  = 8
+        realmSchemaVersion  = 9
     }
     repositories {
         jcenter()


### PR DESCRIPTION
The video https://open.hpi.de/api/v2/videos/d3b1f55f-2e7b-4f5c-9d9b-296ed12b7eec does not have a valid `singleStream` (urls are null) but only lecturer and slides stream which caused crashes.
This fix provides a fallback to one of these in case the `singleStream` is missing.