### PR TITLE
Fix for OsObject.java crash

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -81,7 +81,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
         } ?: run {
             showDeepLinkErrorMessage()
             createChooserFromCurrentIntent()
-            finishActivity()
+            finish()
             CourseViewModel("")
         }
     }
@@ -117,7 +117,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
                 } else {
                     showDeepLinkErrorMessage()
                     createChooserFromCurrentIntent()
-                    finishActivity()
+                    finish()
                 }
                 true
             }
@@ -215,7 +215,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
                                     it.position - 1 // positions in the API are not zero-indexed
                                 ).build(this)
                             )
-                            finishActivity()
+                            finish()
                         } else {
                             showDeepLinkErrorMessage()
                             createChooserFromCurrentIntent()
@@ -298,6 +298,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         adapter?.getItem(viewPager.currentItem)?.onActivityResult(requestCode, resultCode, data)
+        super.onActivityResult(requestCode, resultCode, data)
     }
 
     private fun setAreaState(state: CourseArea.State) {
@@ -334,10 +335,6 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
         enrollButton?.isEnabled = false
         enrollButton?.isClickable = false
         enrollButton?.setText(R.string.btn_starts_soon)
-    }
-
-    private fun finishActivity() {
-        finish()
     }
 
     private fun restartActivity() {
@@ -412,6 +409,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
                         hideProgressDialog()
                         showLoginRequiredToast()
                         openLogin()
+                        finish()
                         true
                     }
                     else                   -> false
@@ -434,7 +432,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
 
                     when (it.code) {
                         NetworkCode.SUCCESS    -> {
-                            finishActivity()
+                            finish()
                             hideProgressDialog()
                         }
                         NetworkCode.NO_NETWORK -> {


### PR DESCRIPTION
Fixes a crash occurring in the following scenario:

The user is logged out > opens a course > clicks on `Enroll` > signs in on the login screen > App crashes

This was caused by leaving the `CourseActivity` open after launching the `LoginActivity`. Upon a successful login, the database is filled with a new `Course` object but the still opened `CourseActivity` has an Observer on the pre-login `Course` database object. As the activity lifecycle is resumed, the framework tries to start listening on that object, which fails.

The fix was closing the `CourseActivity` when launching the `LoginActivity`.


Also, `onActivityResult` should call `super` and I removed the unnecessary `finishActivity` wrapper.