### PR TITLE
Fix for VideoStreamPlayerFragment.kt line 484 crash

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
@@ -62,7 +62,7 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
 
         currentQuality = when {
             videoInfoCallback.isAvailable(VideoMode.HD)   -> VideoMode.HD
-            videoInfoCallback.isAvailable((VideoMode.SD)) -> VideoMode.SD
+            videoInfoCallback.isAvailable(VideoMode.SD)   -> VideoMode.SD
             videoInfoCallback.isAvailable(VideoMode.AUTO) -> VideoMode.AUTO
             else                                          -> throw IllegalArgumentException("No video available")
         }


### PR DESCRIPTION
Fixes a bug of the app crashing when trying to play a video.

The video player was written with the assumption, that a `VideoStream` might contain a `hlsUrl` but must include a `hdUrl` and `sdUrl`.
This course (which can't be found via search btw): https://open.sap.com/api/v2/courses/hanacloud1-1 has a teaser stream with only a `hlsUrl` and `sdUrl` but no `hdUrl`. Because `HD` is the player default when in WiFi (or HD on mobile networks is enabled), the app crashes.

This fix implements a more flexible way of handling the selection of the video to play (+ settings UI) and requires only one of the two non-HLS urls to be available in non-debug mode.