### PR TITLE
Fix for InvalidRow.java line 188 crash

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -30,6 +30,7 @@ import de.xikolo.controllers.section.CourseItemsActivityAutoBundle
 import de.xikolo.controllers.webview.WebViewFragmentAutoBundle
 import de.xikolo.extensions.observe
 import de.xikolo.extensions.observeOnce
+import de.xikolo.extensions.observeUnsafeOnce
 import de.xikolo.managers.UserManager
 import de.xikolo.models.Course
 import de.xikolo.models.dao.EnrollmentDao
@@ -110,7 +111,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
 
         handleItemDeepLink(intent)
         viewModel.course
-            .observeOnce(this) {
+            .observeUnsafeOnce(this) {
                 if (it.isValid) {
                     course = it
                     setupCourse(it)
@@ -206,7 +207,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
         DeepLinkingUtil.getItemIdentifier(intent?.data?.path)?.let { itemId ->
             if (UserManager.isAuthorized) {
                 ItemDao(viewModel.realm).find(IdUtil.base62ToUUID(itemId))
-                    .observeOnce(this) {
+                    .observeUnsafeOnce(this) {
                         if (it.isValid) {
                             startActivity(
                                 CourseItemsActivityAutoBundle.builder(

--- a/app/src/main/java/de/xikolo/extensions/NonNullMediatorLiveData.kt
+++ b/app/src/main/java/de/xikolo/extensions/NonNullMediatorLiveData.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.Observer
+import io.realm.RealmObject
+import io.realm.RealmResults
 
 class NonNullMediatorLiveData<T> : MediatorLiveData<T>()
 
@@ -22,6 +24,10 @@ fun <T> NonNullMediatorLiveData<T>.observe(owner: LifecycleOwner, observer: (t: 
 
 fun <T> LiveData<T>.observe(owner: LifecycleOwner, observer: (t: T) -> Unit): (t: T) -> Unit {
     this.observe(owner, Observer<T> {
+        if ((it is RealmObject && !it.isValid) || (it is RealmResults<*> && !it.isValid)) {
+            return@Observer
+        }
+
         it?.let(observer)
     })
     return observer
@@ -31,7 +37,22 @@ fun <T> LiveData<T>.observe(owner: LifecycleOwner, observer: (t: T) -> Unit): (t
 fun <T> LiveData<T>.observeOnce(owner: LifecycleOwner, observer: (t: T) -> Boolean): (t: T) -> Boolean {
     this.observe(owner, object : Observer<T> {
         override fun onChanged(t: T) {
+            if ((t is RealmObject && !t.isValid) || (t is RealmResults<*> && !t.isValid)) {
+                return
+            }
+
             if (t?.let(observer) == true) {
+                removeObserver(this)
+            }
+        }
+    })
+    return observer
+}
+
+fun <T : RealmObject> LiveData<T>.observeUnsafeOnce(owner: LifecycleOwner, observer: (t: T) -> Boolean): (t: T) -> Boolean {
+    this.observe(owner, object : Observer<T> {
+        override fun onChanged(t: T) {
+            if (t.let(observer)) {
                 removeObserver(this)
             }
         }


### PR DESCRIPTION
Sometimes, for weird reasons (probably concurrency), the code tries to access already deleted Realm objects resulting in a crash: `Fatal Exception: java.lang.IllegalStateException: Object is no longer managed by Realm. Has it been deleted?`

This fix implements a check whether the `RealmObject` or `RealmResult<*>` is actually valid before invoking the `LiveData` observer. This has been baked into the `observe` extension with an instance check. A cleaner solution would have been to have an `observe` extension specifically for `RealmObjectLiveData` objects. But because the Daos, ViewModels and ViewModel delegates declare the type as a plain `LiveData`, I did not want to change the whole codebase and used the former approach.

Some functions rely on the value of `RealmObject.isValid`. The have the extension `observe[Once]Unsafe()` which does not do the check.