### PR TITLE
Fix for CourseListFragment.kt line 119 crash

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
@@ -115,17 +115,19 @@ class CourseListFragment : MainFragment<CourseListViewModel>() {
     }
 
     private fun registerObservers() {
-        viewModel.courses
-            .observe(viewLifecycleOwner) {
-                courseList = viewModel.sectionedCourseList
-                showCourseList()
-            }
+        view?.also {
+            viewModel.courses
+                .observe(viewLifecycleOwner) {
+                    courseList = viewModel.sectionedCourseList
+                    showCourseList()
+                }
 
-        viewModel.dates
-            .observe(viewLifecycleOwner) {
-                courseList = viewModel.sectionedCourseList
-                showCourseList()
-            }
+            viewModel.dates
+                .observe(viewLifecycleOwner) {
+                    courseList = viewModel.sectionedCourseList
+                    showCourseList()
+                }
+        }
     }
 
     private fun unregisterObservers() {


### PR DESCRIPTION
Fixes a crash caused by the course search functionality.

`Fragment.getViewLifecycleOwner()` fails because of a null `getView()` in the `CourseListFragment`. When the search bar is opened and has focus, the keyboard is visible. When the user now opens the drawer menu, clicks on an item and quickly enters something before the keyboard disappears, this app crashes. It happens because the `CourseListFragment` has already been detached and thus the `view` is null, but the search bar is still active and receives an input from the not-yet-closed keyboard.