### PR TITLE
Hotfix for intent chooser extension crash

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -347,9 +347,11 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
     private fun createChooserFromCurrentIntent() {
         intent?.let {
             Handler().postDelayed({
-                startActivity(
-                    Intent(it.action, it.data).createChooser(this, null, arrayOf(this.packageName))
-                )
+                Intent(it.action, it.data).createChooser(this, null, arrayOf(this.packageName))?.let {
+                    startActivity(it)
+                } ?: run {
+                    showToast(R.string.error_plain)
+                }
             }, 300)
         }
     }

--- a/app/src/main/java/de/xikolo/controllers/section/LtiExerciseFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/LtiExerciseFragment.kt
@@ -20,7 +20,10 @@ import de.xikolo.managers.UserManager
 import de.xikolo.models.Item
 import de.xikolo.models.LtiExercise
 import de.xikolo.storages.ApplicationPreferences
-import de.xikolo.utils.extensions.*
+import de.xikolo.utils.extensions.createChooser
+import de.xikolo.utils.extensions.includeAuthToken
+import de.xikolo.utils.extensions.setMarkdownText
+import de.xikolo.utils.extensions.showToast
 import de.xikolo.viewmodels.section.LtiExerciseViewModel
 
 class LtiExerciseFragment : ViewModelFragment<LtiExerciseViewModel>() {
@@ -121,7 +124,11 @@ class LtiExerciseFragment : ViewModelFragment<LtiExerciseViewModel>() {
                 includeAuthToken(UserManager.token!!)
             }
             context?.let { context ->
-                startActivity(intent.createChooser(context, null, arrayOf(context.packageName)))
+                intent.createChooser(context, null, arrayOf(context.packageName))?.let { intent ->
+                    startActivity(intent)
+                } ?: run {
+                    showToast(R.string.error_plain)
+                }
             }
         } ?: run {
             showToast(R.string.error_plain)

--- a/app/src/main/java/de/xikolo/controllers/section/PeerAssessmentFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/PeerAssessmentFragment.kt
@@ -123,7 +123,11 @@ class PeerAssessmentFragment : ViewModelFragment<PeerAssessmentViewModel>() {
                 includeAuthToken(UserManager.token!!)
             }
             context?.let { context ->
-                startActivity(intent.createChooser(context, null, arrayOf(context.packageName)))
+                intent.createChooser(context, null, arrayOf(context.packageName))?.let { intent ->
+                    startActivity(intent)
+                } ?: run {
+                    showToast(R.string.error_plain)
+                }
             }
         } ?: run {
             showToast(R.string.error_plain)

--- a/app/src/main/java/de/xikolo/utils/extensions/IntentExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/IntentExtensions.kt
@@ -3,14 +3,28 @@ package de.xikolo.utils.extensions
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.ACTION_VIEW
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.provider.Browser
 import de.xikolo.config.Config
 
 
-fun <T : Intent> T.createChooser(context: Context, title: String? = null, packagesToHide: Array<String> = emptyArray()): Intent {
-    val resolveInfos = context.packageManager.queryIntentActivities(this, 0)
+fun <T : Intent> T.createChooser(context: Context, title: String? = null, packagesToHide: Array<String> = emptyArray()): Intent? {
+    val fakeIntent = Intent(ACTION_VIEW).apply { data = Uri.parse("http://someurl.com") }
+    val resolveInfos = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        context.packageManager.queryIntentActivities(this, PackageManager.MATCH_ALL) +
+            context.packageManager.queryIntentActivities(fakeIntent, PackageManager.MATCH_ALL)
+    } else {
+        context.packageManager.queryIntentActivities(this, 0) +
+            context.packageManager.queryIntentActivities(fakeIntent, 0)
+    }
     val intents = resolveInfos
+        .distinctBy {
+            it.activityInfo.packageName
+        }
         .filter {
             !packagesToHide.contains(it.activityInfo.packageName)
         }
@@ -22,9 +36,13 @@ fun <T : Intent> T.createChooser(context: Context, title: String? = null, packag
         }
         .toMutableList()
 
-    val chooserIntent = Intent.createChooser(intents.removeAt(0), title)
-    chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intents.toTypedArray())
-    return chooserIntent
+    return try {
+        val chooserIntent = Intent.createChooser(intents.removeAt(0), title)
+        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intents.toTypedArray())
+        chooserIntent
+    } catch (e: IndexOutOfBoundsException) {
+        null
+    }
 }
 
 fun <T : Intent> T.includeAuthToken(token: String) {


### PR DESCRIPTION
Users, which selected to open supported links in the app, will experience a crash trying to open them (e.g. opening a peer assessment).

That's because `PackageManager.queryIntentActivities()` returns only the app itself when such a selection has been made. When that's not the case, all matching applications are resolved. Even the flag `PackageManager.MATCH_ALL` has no effect on this (even though it is recommended to use it >=M). Because the only resolved app would then be filtered out, `intents.removeAt(0)` fails.
There is no way to bypass the framework's pre-filtering.

The workaround works by additionally resolving the intent for some URL to get applications supporting URLs (like browsers). These are merged with the resolved apps for the actual intent (only the app itself in the case of an "open default") and duplicates are removed. There is also error handling for the rare case that no browser or such is installed.