### PR TITLE
Hide proctored items

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/section/CourseItemsActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/CourseItemsActivity.kt
@@ -209,16 +209,18 @@ class CourseItemsActivity : ViewModelActivity<CourseItemsViewModel>() {
             var fragment = fragmentManager.findFragmentByTag(name)
             val url = Config.HOST_URL + Config.COURSES + courseId + "/" + Config.ITEMS + item.id
             if (fragment == null) {
-                when (item.contentType) {
-                    Item.TYPE_LTI   -> fragment = LtiExerciseFragmentAutoBundle.builder(courseId, sectionId, item.id).build()
-                    Item.TYPE_PEER  -> fragment = PeerAssessmentFragmentAutoBundle.builder(courseId, sectionId, item.id).build()
-                    Item.TYPE_QUIZ  -> fragment = WebViewFragmentAutoBundle.builder(url)
+                fragment = if (item.proctored) {
+                    ProctoredItemFragment()
+                } else when (item.contentType) {
+                    Item.TYPE_LTI   -> LtiExerciseFragmentAutoBundle.builder(courseId, sectionId, item.id).build()
+                    Item.TYPE_PEER  -> PeerAssessmentFragmentAutoBundle.builder(courseId, sectionId, item.id).build()
+                    Item.TYPE_QUIZ  -> WebViewFragmentAutoBundle.builder(url)
                         .inAppLinksEnabled(true)
                         .externalLinksEnabled(false)
                         .build()
-                    Item.TYPE_TEXT  -> fragment = RichTextFragmentAutoBundle.builder(courseId, sectionId, item.id).build()
-                    Item.TYPE_VIDEO -> fragment = VideoPreviewFragmentAutoBundle.builder(courseId, sectionId, item.id).build()
-                    else            -> fragment = WebViewFragmentAutoBundle.builder(url)
+                    Item.TYPE_TEXT  -> RichTextFragmentAutoBundle.builder(courseId, sectionId, item.id).build()
+                    Item.TYPE_VIDEO -> VideoPreviewFragmentAutoBundle.builder(courseId, sectionId, item.id).build()
+                    else            -> WebViewFragmentAutoBundle.builder(url)
                         .inAppLinksEnabled(false)
                         .externalLinksEnabled(false)
                         .build()

--- a/app/src/main/java/de/xikolo/controllers/section/CourseItemsActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/CourseItemsActivity.kt
@@ -209,7 +209,7 @@ class CourseItemsActivity : ViewModelActivity<CourseItemsViewModel>() {
             var fragment = fragmentManager.findFragmentByTag(name)
             val url = Config.HOST_URL + Config.COURSES + courseId + "/" + Config.ITEMS + item.id
             if (fragment == null) {
-                fragment = if (item.proctored) {
+                fragment = if (course?.enrollment?.proctored == true && item.proctored) {
                     ProctoredItemFragment()
                 } else when (item.contentType) {
                     Item.TYPE_LTI   -> LtiExerciseFragmentAutoBundle.builder(courseId, sectionId, item.id).build()

--- a/app/src/main/java/de/xikolo/controllers/section/ProctoredItemFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/ProctoredItemFragment.kt
@@ -1,0 +1,37 @@
+package de.xikolo.controllers.section
+
+import android.os.Bundle
+import android.view.View
+import de.xikolo.R
+import de.xikolo.controllers.base.NetworkStateFragment
+
+class ProctoredItemFragment : NetworkStateFragment() {
+
+    companion object {
+        val TAG: String = ProctoredItemFragment::class.java.simpleName
+    }
+
+    override val layoutResource = R.layout.fragment_richtext // does not matter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onRefresh() {
+        showError()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        showError()
+    }
+
+    private fun showError() {
+        hideAnyProgress()
+        showMessage(
+            R.string.not_available,
+            R.string.item_proctored_summary
+        )
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -178,6 +178,7 @@
     <string name="user_name">%1$s %2$s</string>
     <string name="or">oder</string>
     <string name="not_available">Nicht verfügbar</string>
+    <string name="item_proctored_summary">Dieser Inhalt ist auf Mobilgeräten nicht verfügbar, da ein qualifiziertes Zertifikat gebucht wurde. Bitte nutzen Sie einen Computer, um auf den Inhalt zuzugreifen.</string>
 
 
     <string name="self_test_points">%1$.1f von %2$.1f Selbsttest-Punkten</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,6 +183,7 @@
     <string name="login_sso_hint">SSO Login</string>
     <string name="ok">OK</string>
     <string name="not_available">Not available</string>
+    <string name="item_proctored_summary">This item can\'t be accessed on mobile because you booked a qualified certificate. Please use a computer to access it.</string>
 
     <string name="self_test_points">%1$.1f of %2$.1f self-test points</string>
     <string name="assignments_points">%1$.1f of %2$.1f assignment points</string>


### PR DESCRIPTION
When an Item is proctored, the `ProctoredItemFragment` is inflated into the ViewPager right away. 
Is checking `item.proctored == true` enough?
All this Fragment does is showing the warning

`Nicht verfügbar`
`Dieser Inhalt ist auf Mobilgeräten nicht verfügbar, da ein qualifiziertes Zertifikat gebucht wurde. Bitte nutzen Sie einen Computer, um auf den Inhalt zuzugreifen.`

`Not available`
`This item can't be accessed on mobile because you booked a qualified certificate. Please use a computer to access it.`

I tested the Fragment itself by mocking the check but wasn't able to test the actual check because I don't have a proctored course at hand.

Fixes #217 