### PR TITLE
Bugfixes

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
@@ -28,6 +28,7 @@ import de.xikolo.controllers.login.LoginActivityAutoBundle
 import de.xikolo.controllers.settings.SettingsActivity
 import de.xikolo.extensions.observe
 import de.xikolo.managers.UserManager
+import de.xikolo.models.Profile
 import de.xikolo.utils.DeepLinkingUtil
 import de.xikolo.utils.LanalyticsUtil
 import de.xikolo.utils.extensions.checkPlayServicesWithDialog
@@ -259,14 +260,14 @@ class MainActivity : ViewModelActivity<NavigationViewModel>(), NavigationView.On
             }
 
             viewModel.user?.let { user ->
-                val profile = user.profile
+                val profile: Profile? = user.profile
                 headerView.findViewById<TextView>(R.id.textName).text = String.format(
                     getString(R.string.user_name),
-                    profile.firstName,
-                    profile.lastName
+                    profile?.firstName ?: "",
+                    profile?.lastName ?: ""
                 )
 
-                headerView.findViewById<TextView>(R.id.textEmail).text = profile.email
+                headerView.findViewById<TextView>(R.id.textEmail).text = profile?.email ?: ""
 
                 GlideApp.with(this)
                     .load(user.avatarUrl)

--- a/app/src/main/java/de/xikolo/controllers/video/VideoStreamPlayerFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoStreamPlayerFragment.kt
@@ -715,7 +715,10 @@ open class VideoStreamPlayerFragment : BaseFragment() {
     }
 
     override fun onDestroy() {
-        playerView.release()
+        // onDestroy is called regardless of whether the fragment's view has been created. If this is not the case, the call to playerView will fail.
+        if(view != null) {
+            playerView.release()
+        }
         seekBarPreviewThread.quit()
         super.onDestroy()
     }


### PR DESCRIPTION
**Fix for VideoStreamPlayerFragment.kt line 718**
`onDestroy` is called regardless of whether the fragment's view has been created. If this is not the case, the call to the then-null `playerView` will fail.

**Fix for MainActivity.kt line 265, LoginFragment.kt line 229**
The login process consists of two consecutive requests: first the actual login and then fetching the profile. When the user has a slow network connection and leaves the fragment while the first request is running but not the second, the MainActivity would try to operate on a null Profile.
The callbacks of the network requests are correct. When one request errors, the whole process should be undone. But because the observe functions only have the scope of an active fragment, they might not get called when the request errors while the fragment is not active.
When the second is running and the user leaves the fragment, once the observe is invoked, hiding the progress fails because the fragment view has been destroyed.