### PR TITLE
Migrate to APIv4

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
@@ -3,7 +3,6 @@ package de.xikolo.controllers.main
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.TextView
@@ -14,9 +13,7 @@ import androidx.drawerlayout.widget.DrawerLayout
 import butterknife.BindView
 import com.google.android.material.navigation.NavigationView
 import de.xikolo.App
-import de.xikolo.BuildConfig
 import de.xikolo.R
-import de.xikolo.config.Config
 import de.xikolo.config.Feature
 import de.xikolo.config.GlideApp
 import de.xikolo.controllers.base.BaseFragment
@@ -29,7 +26,6 @@ import de.xikolo.controllers.login.LoginActivityAutoBundle
 import de.xikolo.controllers.settings.SettingsActivity
 import de.xikolo.extensions.observe
 import de.xikolo.managers.UserManager
-import de.xikolo.models.Profile
 import de.xikolo.utils.DeepLinkingUtil
 import de.xikolo.utils.LanalyticsUtil
 import de.xikolo.utils.extensions.checkPlayServicesWithDialog
@@ -284,14 +280,9 @@ class MainActivity : ViewModelActivity<NavigationViewModel>(), NavigationView.On
             }
 
             viewModel.user?.let { user ->
-                val profile: Profile? = user.profile
-                headerView.findViewById<TextView>(R.id.textName).text = String.format(
-                    getString(R.string.user_name),
-                    profile?.firstName ?: "",
-                    profile?.lastName ?: ""
-                )
+                headerView.findViewById<TextView>(R.id.textName).text = user.name
 
-                headerView.findViewById<TextView>(R.id.textEmail).text = profile?.email ?: ""
+                headerView.findViewById<TextView>(R.id.textEmail).text = user.profile.email
 
                 GlideApp.with(this)
                     .load(user.avatarUrl)

--- a/app/src/main/java/de/xikolo/controllers/main/ProfileFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/ProfileFragment.kt
@@ -21,6 +21,9 @@ class ProfileFragment : MainFragment<ProfileViewModel>() {
         val TAG: String = ProfileFragment::class.java.simpleName
     }
 
+    @BindView(R.id.textFullName)
+    lateinit var textFullName: TextView
+
     @BindView(R.id.textName)
     lateinit var textName: TextView
 
@@ -58,17 +61,17 @@ class ProfileFragment : MainFragment<ProfileViewModel>() {
     }
 
     private fun showUser(user: User) {
-        val userTitle = String.format(
-            getString(R.string.user_name),
-            user.profile.firstName,
-            user.profile.lastName
-        )
+        activityCallback?.onFragmentAttached(R.id.navigation_login, user.name)
 
-        activityCallback?.onFragmentAttached(R.id.navigation_login, userTitle)
+        if (user.name == user.profile.fullName) {
+            textFullName.text = user.name
+            textName.visibility = View.GONE
+        } else {
+            textFullName.text = user.profile.fullName
+            textName.text = user.name
+        }
 
-        textName.text = userTitle
         textEmail.text = user.profile.email
-
 
         val size = activity.displaySize
         val heightHeader: Int

--- a/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/VideoPreviewFragment.kt
@@ -111,7 +111,7 @@ class VideoPreviewFragment : ViewModelFragment<VideoPreviewViewModel>() {
             .override(imageVideoThumbnail.forcedWidth, imageVideoThumbnail.forcedHeight)
             .into(imageVideoThumbnail)
 
-        textTitle.text = video.title
+        textTitle.text = item.title
 
         linearLayoutDownloads.removeAllViews()
         downloadViewHelpers.clear()

--- a/app/src/main/java/de/xikolo/models/Channel.java
+++ b/app/src/main/java/de/xikolo/models/Channel.java
@@ -3,9 +3,10 @@ package de.xikolo.models;
 import android.graphics.Color;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
+
 import com.squareup.moshi.Json;
 
-import androidx.core.content.ContextCompat;
 import de.xikolo.App;
 import de.xikolo.R;
 import de.xikolo.config.Config;
@@ -23,8 +24,6 @@ public class Channel extends RealmObject {
     public String id;
 
     public String title;
-
-    public String slug;
 
     public String color;
 
@@ -52,8 +51,6 @@ public class Channel extends RealmObject {
 
         public String title;
 
-        public String slug;
-
         public String color;
 
         public int position;
@@ -71,7 +68,6 @@ public class Channel extends RealmObject {
             Channel model = new Channel();
             model.id = getId();
             model.title = title;
-            model.slug = slug;
             model.color = color;
             model.position = position;
             model.description = description;

--- a/app/src/main/java/de/xikolo/models/CourseProgress.java
+++ b/app/src/main/java/de/xikolo/models/CourseProgress.java
@@ -37,7 +37,7 @@ public class CourseProgress extends RealmObject {
         @Json(name = "visits")
         public VisitStatistic visits;
 
-        @Json(name = "section-progresses")
+        @Json(name = "section_progresses")
         public HasMany<SectionProgress.JsonModel> sectionProgresses;
 
         @Override

--- a/app/src/main/java/de/xikolo/models/Profile.java
+++ b/app/src/main/java/de/xikolo/models/Profile.java
@@ -14,9 +14,7 @@ public class Profile extends RealmObject {
     @PrimaryKey
     public String id;
 
-    public String firstName;
-
-    public String lastName;
+    public String fullName;
 
     public String displayName;
 
@@ -25,11 +23,8 @@ public class Profile extends RealmObject {
     @JsonApi(type = "user-profile")
     public static class JsonModel extends Resource implements RealmAdapter<Profile> {
 
-        @Json(name = "first_name")
-        public String firstName;
-
-        @Json(name = "last_name")
-        public String lastName;
+        @Json(name = "full_name")
+        public String fullName;
 
         @Json(name = "display_name")
         public String displayName;
@@ -40,8 +35,7 @@ public class Profile extends RealmObject {
         public Profile convertToRealmObject() {
             Profile model = new Profile();
             model.id = getId();
-            model.firstName = firstName;
-            model.lastName = lastName;
+            model.fullName = fullName;
             model.displayName = displayName;
             model.email = email;
             return model;

--- a/app/src/main/java/de/xikolo/models/Quiz.java
+++ b/app/src/main/java/de/xikolo/models/Quiz.java
@@ -19,8 +19,6 @@ public class Quiz extends RealmObject {
 
     public int allowedAttempts;
 
-    public int maxPoints;
-
     public boolean showWelcomePage;
 
     @JsonApi(type = "quizzes")
@@ -47,7 +45,6 @@ public class Quiz extends RealmObject {
             quiz.instructions = instructions;
             quiz.timeLimit = timeLimit;
             quiz.allowedAttempts = allowedAttempts;
-            quiz.maxPoints = maxPoints;
             quiz.showWelcomePage = showWelcomePage;
 
             return quiz;

--- a/app/src/main/java/de/xikolo/models/SectionProgress.java
+++ b/app/src/main/java/de/xikolo/models/SectionProgress.java
@@ -51,7 +51,7 @@ public class SectionProgress extends RealmObject {
         @Json(name = "visits")
         public VisitStatistic visits;
 
-        @Json(name = "course-progress")
+        @Json(name = "course_progress")
         public HasOne<CourseProgress.JsonModel> courseProgress;
 
         @Override

--- a/app/src/main/java/de/xikolo/models/Video.java
+++ b/app/src/main/java/de/xikolo/models/Video.java
@@ -5,6 +5,7 @@ import com.squareup.moshi.Json;
 import java.util.List;
 
 import de.xikolo.models.base.RealmAdapter;
+import de.xikolo.models.dao.ItemDao;
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
@@ -15,8 +16,6 @@ public class Video extends RealmObject {
 
     @PrimaryKey
     public String id;
-
-    public String title;
 
     public String summary;
 
@@ -44,6 +43,10 @@ public class Video extends RealmObject {
 
     public RealmList<VideoSubtitles> subtitles = new RealmList<>();
 
+    public Item getItem() {
+        return ItemDao.Unmanaged.findForContent(id);
+    }
+
     // local field
     public int progress = 0;
 
@@ -61,8 +64,6 @@ public class Video extends RealmObject {
 
     @JsonApi(type = "videos")
     public static class JsonModel extends Resource implements RealmAdapter<Video> {
-
-        public String title;
 
         public String summary;
 
@@ -104,7 +105,6 @@ public class Video extends RealmObject {
         public Video convertToRealmObject() {
             Video video = new Video();
             video.id = getId();
-            video.title = title;
             video.summary = summary;
             video.duration = duration;
             video.singleStream = singleStream;

--- a/app/src/main/java/de/xikolo/models/dao/ItemDao.kt
+++ b/app/src/main/java/de/xikolo/models/dao/ItemDao.kt
@@ -34,6 +34,15 @@ class ItemDao(realm: Realm) : BaseDao<Item>(Item::class, realm) {
                 }
 
             @JvmStatic
+            fun findForContent(contentId: String?): Item? =
+                Realm.getDefaultInstance().use { realm ->
+                    realm.where<Item>()
+                        .equalTo("contentId", contentId)
+                        .findFirst()
+                        ?.asCopy()
+                }
+
+            @JvmStatic
             fun findContent(id: String?): RealmObject? =
                 Realm.getDefaultInstance().use { realm ->
                     val item = find(id)

--- a/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
+++ b/app/src/main/java/de/xikolo/models/migrate/RealmSchemaMigration.java
@@ -151,6 +151,16 @@ public class RealmSchemaMigration implements RealmMigration {
         if (oldVersion == 11) {
             schema.get("Item").addField("timeEffort", int.class);
         }
+
+        if (oldVersion == 12) {
+            schema.get("Video").removeField("title");
+            schema.get("Channel").removeField("slug");
+            schema.get("Quiz").removeField("maxPoints");
+            schema.get("Profile").removeField("firstName");
+            schema.get("Profile").removeField("lastName");
+
+            schema.get("Profile").addField("fullName", String.class);
+        }
     }
 
 }

--- a/app/src/main/java/de/xikolo/utils/extensions/CastExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/CastExtensions.kt
@@ -89,7 +89,7 @@ fun <T : Video> T.cast(activity: Activity, autoPlay: Boolean): PendingResult<Rem
 
         //build cast metadata
         val mediaMetadata = MediaMetadata(MediaMetadata.MEDIA_TYPE_MOVIE)
-        mediaMetadata.putString(MediaMetadata.KEY_TITLE, title)
+        mediaMetadata.putString(MediaMetadata.KEY_TITLE, item.title)
 
         val image = WebImage(Uri.parse(thumbnailUrl))
 

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -30,7 +30,7 @@
                 android:elevation="2dp" />
 
             <TextView
-                android:id="@+id/textName"
+                android:id="@+id/textFullName"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/imageProfile"
@@ -39,6 +39,15 @@
                 android:paddingTop="16dp"
                 android:paddingBottom="2dp"
                 android:textSize="20sp" />
+
+            <TextView
+                android:id="@+id/textName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/textFullName"
+                android:layout_centerHorizontal="true"
+                android:paddingBottom="2dp"
+                android:textSize="16sp" />
 
             <TextView
                 android:id="@+id/textEmail"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -177,7 +177,6 @@
     <string name="available_at">Verfügbar ab %1$s</string>
     <string name="download_all_content">Inhalte herunterladen</string>
     <string name="intro_overlay_text">Berühren, um Videos auf den Fernseher zu casten</string>
-    <string name="user_name">%1$s %2$s</string>
     <string name="or">oder</string>
     <string name="login_sso">SSO</string>
     <string name="login_sso_hint">SSO Login</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,7 +177,6 @@
     <string name="available_at">Available at %1$s</string>
     <string name="download_all_content">Download contents</string>
     <string name="intro_overlay_text">Touch to cast videos on TV</string>
-    <string name="user_name">%1$s %2$s</string>
     <string name="or">or</string>
     <string name="login_sso">SSO</string>
     <string name="login_sso_hint">SSO Login</string>

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ buildscript {
         versionName         = "3.1.1"
         versionCode         = 52
 
-        xikoloApiVersion    = 3
-        realmSchemaVersion  = 12
+        xikoloApiVersion    = 4
+        realmSchemaVersion  = 13
     }
     repositories {
         jcenter()


### PR DESCRIPTION
Deprecated stuff:
- `title` in `videos` (use `title` from `course-items`)
- `slug` in `channels` (use `id`)
- `max_points` in `quizzes` (use `max_points` from `course-items`)
- `first_name` and `last_name` from `user-profile` (use `full_name`)
- `section-progresses` relation in `course-progresses` (use `section_progresses`)
- `course-progress` relation in `section-progresses` (use `course_progress`)