### PR TITLE
v3.2 Hotfixes

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/login/LoginFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/login/LoginFragment.kt
@@ -111,7 +111,7 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
 
         buttonNew.setOnClickListener {
             hideKeyboard(view)
-            if(activity?.openUrl(Config.HOST_URL + Config.ACCOUNT + Config.NEW) != true){
+            if (activity?.openUrl(Config.HOST_URL + Config.ACCOUNT + Config.NEW) != true) {
                 showToast(R.string.error_plain)
             }
         }
@@ -127,7 +127,7 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
 
         textForgotPassword.setOnClickListener {
             hideKeyboard(view)
-            if(activity?.openUrl(Config.HOST_URL + Config.ACCOUNT + Config.RESET) != true){
+            if (activity?.openUrl(Config.HOST_URL + Config.ACCOUNT + Config.RESET) != true) {
                 showToast(R.string.error_plain)
             }
         }

--- a/app/src/main/java/de/xikolo/controllers/login/LoginFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/login/LoginFragment.kt
@@ -1,8 +1,6 @@
 package de.xikolo.controllers.login
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
@@ -29,6 +27,7 @@ import de.xikolo.network.jobs.base.NetworkCode
 import de.xikolo.network.jobs.base.NetworkState
 import de.xikolo.storages.UserStorage
 import de.xikolo.utils.extensions.getString
+import de.xikolo.utils.extensions.openUrl
 import de.xikolo.utils.extensions.showToast
 import de.xikolo.viewmodels.login.LoginViewModel
 
@@ -112,7 +111,9 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
 
         buttonNew.setOnClickListener {
             hideKeyboard(view)
-            startUrlIntent(Config.HOST_URL + Config.ACCOUNT + Config.NEW)
+            if(activity?.openUrl(Config.HOST_URL + Config.ACCOUNT + Config.NEW) != true){
+                showToast(R.string.error_plain)
+            }
         }
 
 
@@ -126,7 +127,9 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
 
         textForgotPassword.setOnClickListener {
             hideKeyboard(view)
-            startUrlIntent(Config.HOST_URL + Config.ACCOUNT + Config.RESET)
+            if(activity?.openUrl(Config.HOST_URL + Config.ACCOUNT + Config.RESET) != true){
+                showToast(R.string.error_plain)
+            }
         }
 
         viewModel.loginNetworkState
@@ -246,12 +249,6 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
 
     private fun isEmailValid(email: CharSequence): Boolean {
         return android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()
-    }
-
-    private fun startUrlIntent(url: String) {
-        val intent = Intent(Intent.ACTION_VIEW)
-        intent.data = Uri.parse(url)
-        startActivity(intent)
     }
 
     override fun onRefresh() {

--- a/app/src/main/java/de/xikolo/controllers/login/LoginFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/login/LoginFragment.kt
@@ -24,8 +24,6 @@ import de.xikolo.config.Config
 import de.xikolo.config.Feature
 import de.xikolo.config.GlideApp
 import de.xikolo.controllers.base.ViewModelFragment
-import de.xikolo.controllers.dialogs.ProgressDialogIndeterminate
-import de.xikolo.controllers.dialogs.ProgressDialogIndeterminateAutoBundle
 import de.xikolo.managers.UserManager
 import de.xikolo.network.jobs.base.NetworkCode
 import de.xikolo.network.jobs.base.NetworkState
@@ -72,8 +70,6 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
 
     @BindView(R.id.ssoContainer)
     lateinit var containerSSO: View
-
-    private var progressDialog: ProgressDialogIndeterminate = ProgressDialogIndeterminateAutoBundle.builder().build()
 
     override val layoutResource = R.layout.fragment_login
 
@@ -159,9 +155,7 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
 
                                 App.instance.state.login.loggedIn()
 
-                                if (this@LoginFragment.view != null) {
-                                    hideProgressDialog()
-                                }
+                                hideAnyProgress()
                                 activity?.finish()
                             }
                             else                -> handleCode(it.code)
@@ -182,7 +176,7 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
         }
 
         token?.let {
-            showProgressDialog()
+            showBlockingProgress()
 
             val userStorage = UserStorage()
             userStorage.accessToken = it
@@ -194,9 +188,9 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
     private fun handleCode(code: NetworkCode) {
         if (code != NetworkCode.STARTED && code != NetworkCode.SUCCESS) {
             UserManager.logout()
-            hideProgressDialog()
+            hideAnyProgress()
             when (code) {
-                NetworkCode.NO_NETWORK -> showNoNetworkToast()
+                NetworkCode.NO_NETWORK -> showNetworkRequired()
                 else                   -> showLoginFailedToast()
             }
         }
@@ -217,7 +211,7 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
             return
         }
 
-        showProgressDialog()
+        showBlockingProgress()
         viewModel.login(email, password)
     }
 
@@ -229,18 +223,6 @@ class LoginFragment : ViewModelFragment<LoginViewModel>() {
             getString(R.string.login_sso)
         ).build(activity!!)
         startActivity(intent)
-    }
-
-    private fun showProgressDialog() {
-        progressDialog.show(childFragmentManager, ProgressDialogIndeterminate.TAG)
-    }
-
-    private fun hideProgressDialog() {
-        progressDialog.dismiss()
-    }
-
-    private fun showNoNetworkToast() {
-        showToast(R.string.toast_no_network)
     }
 
     private fun showLoginFailedToast() {

--- a/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
@@ -139,7 +139,7 @@ class CourseListFragment : MainFragment<CourseListViewModel>() {
     }
 
     private fun unregisterObservers() {
-        if(view != null) {
+        if (view != null) {
             viewModel.courses.removeObservers(viewLifecycleOwner)
             viewModel.dates.removeObservers(viewLifecycleOwner)
         }

--- a/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
@@ -194,7 +194,7 @@ class CourseListFragment : MainFragment<CourseListViewModel>() {
                 (activity as? BaseActivity)?.setScrollingBehavior(false) // lock action bar in place
                 networkStateHelper.enableSwipeRefresh(false)
 
-                castItem.isVisible = false
+                castItem?.isVisible = false
 
                 filterView.update()
                 filterView.onFilterChangeListener = {
@@ -208,7 +208,7 @@ class CourseListFragment : MainFragment<CourseListViewModel>() {
                 (activity as? BaseActivity)?.setScrollingBehavior(true) // make action bar auto-hide again
                 networkStateHelper.enableSwipeRefresh(true)
 
-                castItem.isVisible = true
+                castItem?.isVisible = true
 
                 filterView.visibility = View.GONE
                 filterView.clear()

--- a/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
@@ -139,8 +139,10 @@ class CourseListFragment : MainFragment<CourseListViewModel>() {
     }
 
     private fun unregisterObservers() {
-        viewModel.courses.removeObservers(viewLifecycleOwner)
-        viewModel.dates.removeObservers(viewLifecycleOwner)
+        if(view != null) {
+            viewModel.courses.removeObservers(viewLifecycleOwner)
+            viewModel.dates.removeObservers(viewLifecycleOwner)
+        }
     }
 
     override fun onStart() {

--- a/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
@@ -282,7 +282,7 @@ class MainActivity : ViewModelActivity<NavigationViewModel>(), NavigationView.On
             viewModel.user?.let { user ->
                 headerView.findViewById<TextView>(R.id.textName).text = user.name
 
-                headerView.findViewById<TextView>(R.id.textEmail).text = user.profile.email
+                headerView.findViewById<TextView>(R.id.textEmail).text = user.profile?.email
 
                 GlideApp.with(this)
                     .load(user.avatarUrl)

--- a/app/src/main/java/de/xikolo/controllers/video/VideoStreamPlayerFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/video/VideoStreamPlayerFragment.kt
@@ -714,11 +714,12 @@ open class VideoStreamPlayerFragment : BaseFragment() {
         super.onStop()
     }
 
+    override fun onDestroyView() {
+        playerView.release()
+        super.onDestroyView()
+    }
+
     override fun onDestroy() {
-        // onDestroy is called regardless of whether the fragment's view has been created. If this is not the case, the call to playerView will fail.
-        if(view != null) {
-            playerView.release()
-        }
         seekBarPreviewThread.quit()
         super.onDestroy()
     }

--- a/app/src/main/java/de/xikolo/models/dao/ChannelDao.kt
+++ b/app/src/main/java/de/xikolo/models/dao/ChannelDao.kt
@@ -17,11 +17,7 @@ class ChannelDao(realm: Realm) : BaseDao<Channel>(Channel::class, realm) {
 
     override fun find(id: String?): LiveData<Channel> =
         query()
-            .beginGroup()
-                .equalTo("id", id)
-                .or()
-                .equalTo("slug", id)
-            .endGroup()
+            .equalTo("id", id)
             .findFirstAsync()
             .asLiveData()
 

--- a/app/src/main/java/de/xikolo/utils/extensions/IntentExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/IntentExtensions.kt
@@ -1,5 +1,6 @@
 package de.xikolo.utils.extensions
 
+import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -49,4 +50,15 @@ fun <T : Intent> T.includeAuthToken(token: String) {
     val headers = Bundle()
     headers.putString(Config.HEADER_AUTH, Config.HEADER_AUTH_VALUE_PREFIX + token)
     putExtra(Browser.EXTRA_HEADERS, headers)
+}
+
+fun <T : Context> T.openUrl(url: String): Boolean {
+    val intent = Intent(ACTION_VIEW)
+    intent.data = Uri.parse(url)
+    return try {
+        startActivity(intent)
+        true
+    } catch (E: ActivityNotFoundException) {
+        false
+    }
 }

--- a/app/src/main/java/de/xikolo/utils/extensions/ToastExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/ToastExtensions.kt
@@ -16,5 +16,5 @@ fun <T : Context> T.showToast(@StringRes stringId: Int) {
 }
 
 fun <T : Fragment> T.showToast(@StringRes stringId: Int) {
-    Toast.makeText(this.activity, this.getString(stringId), Toast.LENGTH_SHORT).show()
+    this.activity?.showToast(stringId)
 }

--- a/app/src/main/java/de/xikolo/viewmodels/main/NavigationViewModel.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/main/NavigationViewModel.kt
@@ -4,12 +4,15 @@ import de.xikolo.R
 import de.xikolo.managers.UserManager
 import de.xikolo.models.dao.AnnouncementDao
 import de.xikolo.models.dao.UserDao
+import de.xikolo.network.jobs.base.NetworkStateLiveData
 import de.xikolo.viewmodels.base.BaseViewModel
 import de.xikolo.viewmodels.shared.AnnouncementListDelegate
+import de.xikolo.viewmodels.shared.UserDelegate
 
 class NavigationViewModel : BaseViewModel() {
 
     private val announcementListDelegate = AnnouncementListDelegate(realm)
+    private val userDelegate = UserDelegate(realm)
 
     val announcements = announcementListDelegate.announcements
 
@@ -28,10 +31,12 @@ class NavigationViewModel : BaseViewModel() {
 
     override fun onFirstCreate() {
         announcementListDelegate.requestAnnouncementList(networkState, false)
+        userDelegate.requestUserWithProfile(NetworkStateLiveData(), false)
     }
 
     override fun onRefresh() {
         announcementListDelegate.requestAnnouncementList(networkState, true)
+        userDelegate.requestUserWithProfile(NetworkStateLiveData(), false)
     }
 
 }

--- a/app/src/main/java/de/xikolo/viewmodels/section/CourseItemsViewModel.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/section/CourseItemsViewModel.kt
@@ -24,9 +24,10 @@ class CourseItemsViewModel(courseId: String, sectionId: String) : BaseViewModel(
     }
 
     fun markItemVisited(item: Item) {
-        realm.beginTransaction()
-        item.visited = true
-        realm.commitTransaction()
+        realm.executeTransaction {
+            item.visited = true
+            it.copyToRealmOrUpdate(item)
+        }
 
         UpdateItemVisitedJob.schedule(item.id)
     }


### PR DESCRIPTION
Fixes the most critical and some extra bugs introduced with the latest version.

**Fix for CachedFieldDescriptor.java line 80**
The API v3 field `Channel.slug` was accessed in `ChannelDao`

**Fix for VideoStreamPlayerFragment.kt line 602, 612, 618**
The video player view was not released properly leading to callback events occurring after the fragment had been destroyed

**Fix for LoginFragment.kt line 239**
We had an own progress dialog and missed to check whether it has actually been shown when calling `dismiss`. We now use the `NetworkStateHelper.showBlockingProgress`  implementation.
Also, the `showToast` extension on `Fragment` was using the context of the fragment which led to crashes when the fragment had been destroyed. We now use the activity context.

**Fix for MainActivity.kt line 285**
In rare cases `<user>.profile` can be null (see #224 ). A call to `profile.email` would fail. Replaced with a safe call.

**Fix for OsSharedRealm.java**
The way we handled the transaction was somewhat odd. We also did not update the database object. I changed it to the approach we usually use in our code. Don't know if this will fix it.

**Fix for LoginFragment.kt line 272**
Some users seem to not have an app installed to open `https://openwho.org`. An exception occurred trying to start an url intent. I added an `openUrl()` extension with proper error handling.

**Fix for CourseListFragment.kt line 142**
Course list observers were unregistered after the fragment had been destroyed, because the search text had been changed somehow (probably when hiding the view).

**Fix for CourseListFragment.kt line 195**
For devices without Play Services, the cast icon will not be inflated into the menu. Trying to hide it will fail because it's null. Simple safe calls fix this.