### PR TITLE
Fix hiding of course dates menu icon

### DIFF
--- a/app/src/main/java/de/xikolo/viewmodels/course/CourseViewModel.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/course/CourseViewModel.kt
@@ -1,5 +1,7 @@
 package de.xikolo.viewmodels.course
 
+import androidx.lifecycle.LiveData
+import de.xikolo.models.CourseDate
 import de.xikolo.network.jobs.base.NetworkStateLiveData
 import de.xikolo.viewmodels.base.BaseViewModel
 import de.xikolo.viewmodels.shared.CourseDelegate
@@ -14,7 +16,9 @@ class CourseViewModel(private val courseId: String) : BaseViewModel() {
 
     val course = courseDelegate.course
 
-    val dates = dateListDelegate.dates
+    val dates: LiveData<List<CourseDate>> by lazy {
+        dateListDelegate.datesForCourse(courseId)
+    }
 
     val dateCount: Int
         get() = dates.value?.size ?: 0

--- a/app/src/main/java/de/xikolo/viewmodels/main/DateListViewModel.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/main/DateListViewModel.kt
@@ -16,13 +16,11 @@ open class DateListViewModel(private val courseId: String? = null) : BaseViewMod
     private val courseListDelegate = CourseListDelegate(realm)
     private val dateListDelegate = DateListDelegate(realm)
 
-    private val dateDao = DateDao(realm)
-
     val dates: LiveData<List<CourseDate>> by lazy {
         if (courseId != null) {
-            dateDao.allForCourse(courseId)
+            dateListDelegate.datesForCourse(courseId)
         } else {
-            dateDao.all()
+            dateListDelegate.dates
         }
     }
 
@@ -102,5 +100,4 @@ open class DateListViewModel(private val courseId: String? = null) : BaseViewMod
         courseListDelegate.requestCourseList(networkState, true)
         dateListDelegate.requestDateList(networkState, true)
     }
-
 }

--- a/app/src/main/java/de/xikolo/viewmodels/shared/DateListDelegate.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/shared/DateListDelegate.kt
@@ -15,8 +15,11 @@ class DateListDelegate(realm: Realm) {
         dateDao.all()
     }
 
+    fun datesForCourse(courseId: String): LiveData<List<CourseDate>> {
+        return dateDao.allForCourse(courseId)
+    }
+
     fun requestDateList(networkState: NetworkStateLiveData, userRequest: Boolean) {
         ListDatesJob(networkState, userRequest).run()
     }
-
 }


### PR DESCRIPTION
The problem was that checking was not done against the number of dates of the specific course but all dates globally. This meant the icon was shown in every course when the user had any upcoming dates.

Fixes #241 