### PR TITLE
Fix deeplink issues

### DIFF
--- a/app/src/androidTest/java/de/xikolo/testing/instrumented/unit/DeepLinkingUtilTest.kt
+++ b/app/src/androidTest/java/de/xikolo/testing/instrumented/unit/DeepLinkingUtilTest.kt
@@ -15,28 +15,90 @@ class DeepLinkingUtilTest : BaseTest() {
     fun testCourseIdentification() {
         assertEquals(
             "123456",
-            DeepLinkingUtil.getCourseIdentifier(Uri.parse("https://open.hpi.de/courses/123456"))
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456")
+            )
         )
 
         assertEquals(
             "123456",
-            DeepLinkingUtil.getCourseIdentifier(Uri.parse("https://open.hpi.de/courses/123456/resume"))
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456/")
+            )
         )
 
         assertEquals(
             "123456",
-            DeepLinkingUtil.getCourseIdentifier(Uri.parse("https://open.hpi.de/courses/123456/items/654321"))
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456/resume")
+            )
+        )
+
+        assertEquals(
+            "123456",
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456/resume/")
+            )
+        )
+
+        assertNull(
+            "123456",
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456/resume/something")
+            )
+        )
+
+        assertEquals(
+            "123456",
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456/items/654321")
+            )
+        )
+
+        assertNull(
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456/items/654321/something")
+            )
+        )
+
+        assertNull(
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456/items/654321/something/")
+            )
+        )
+
+        assertEquals(
+            "123456",
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456/items/654321/")
+            )
         )
 
         if (Feature.enabled("recap")) {
             assertEquals(
                 "123456",
-                DeepLinkingUtil.getCourseIdentifier(Uri.parse("https://open.hpi.de/learn?course_id=123456"))
+                DeepLinkingUtil.getCourseIdentifier(
+                    Uri.parse("https://open.hpi.de/learn?course_id=123456")
+                )
             )
         }
 
         assertNull(
-            DeepLinkingUtil.getCourseIdentifier(Uri.parse("https://open.hpi.de/invalid"))
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/invalid")
+            )
+        )
+
+        assertNull(
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456/something")
+            )
+        )
+
+        assertNull(
+            DeepLinkingUtil.getCourseIdentifier(
+                Uri.parse("https://open.hpi.de/courses/123456/something/more")
+            )
         )
     }
 
@@ -47,12 +109,33 @@ class DeepLinkingUtilTest : BaseTest() {
             DeepLinkingUtil.getItemIdentifier("/courses/123456/items/654321")
         )
 
+        assertEquals(
+            "654321",
+            DeepLinkingUtil.getItemIdentifier("/courses/123456/items/654321/")
+        )
+
         assertNull(
             DeepLinkingUtil.getItemIdentifier("/courses/123456/items")
         )
 
         assertNull(
+            DeepLinkingUtil.getItemIdentifier("/courses/123456/items/")
+        )
+
+        assertNull(
             DeepLinkingUtil.getItemIdentifier("/courses/items/654321")
+        )
+
+        assertNull(
+            DeepLinkingUtil.getItemIdentifier("/courses/items/654321/")
+        )
+
+        assertNull(
+            DeepLinkingUtil.getItemIdentifier("/courses/123456/items/654321/something")
+        )
+
+        assertNull(
+            DeepLinkingUtil.getItemIdentifier("/courses/123456/items/654321/something/")
         )
     }
 

--- a/app/src/androidTest/java/de/xikolo/testing/instrumented/unit/DeepLinkingUtilTest.kt
+++ b/app/src/androidTest/java/de/xikolo/testing/instrumented/unit/DeepLinkingUtilTest.kt
@@ -11,6 +11,10 @@ import org.junit.Test
 
 class DeepLinkingUtilTest : BaseTest() {
 
+    /**
+     * Tests the course id extraction from a given url.
+     * Tests also if this works with a trailing slash in the path.
+     */
     @Test
     fun testCourseIdentification() {
         assertEquals(
@@ -102,6 +106,10 @@ class DeepLinkingUtilTest : BaseTest() {
         )
     }
 
+    /**
+     * Tests the item id extraction from a given course url.
+     * Tests also if this works with a trailing slash in the path.
+     */
     @Test
     fun testItemIdentification() {
         assertEquals(

--- a/app/src/main/java/de/xikolo/utils/DeepLinkingUtil.kt
+++ b/app/src/main/java/de/xikolo/utils/DeepLinkingUtil.kt
@@ -23,19 +23,42 @@ object DeepLinkingUtil {
         ALL_COURSES, NEWS, MY_COURSES
     }
 
+    /**
+     * Matches:
+     * Course root path /courses/{course_id}
+     * Course resume path /courses/{course_id}/resume
+     * Course pinboard path /courses/{course_id}/pinboard
+     * Course progress path /courses/{course_id}/progress
+     * Course announcements path /courses/{course_id}/announcements
+     * Course items path /courses/{course_id}/items/.*
+     *
+     * Ignores:
+     * Invalid action /courses/{course_id}/something_invalid
+     * Invalid action path /courses/{course_id}/resume/something
+     * Item sub paths /courses/{course_id}/items/{item_id]/something
+     */
     fun getCourseIdentifier(uri: Uri?): String? {
         return uri?.let {
             it.path?.let { path ->
                 if (path.matches("$ROUTE_COURSES$SLASH.*".toRegex())) {
                     path
+                        .let { s ->
+                            if (!s.endsWith(SLASH)) {
+                                s.plus(SLASH)
+                            } else s
+                        }
                         .replace(ROUTE_COURSES, "")
                         .replace(ROUTE_COURSE_RESUME, "")
                         .replace(ROUTE_COURSE_PINBOARD, "")
                         .replace(ROUTE_COURSE_PROGRESS, "")
                         .replace(ROUTE_COURSE_ANNOUNCEMENTS, "")
-                        .replaceAfter(ROUTE_COURSE_ITEMS, "")
-                        .replace(ROUTE_COURSE_ITEMS, "")
-                        .replace(SLASH, "")
+                        .replace("$ROUTE_COURSE_ITEMS$SLASH.+?$SLASH".toRegex(), "/")
+                        .replaceFirst(SLASH, "")
+                        // leaves any / or /something at the end
+                        .takeUnless {
+                            it.matches(".+$SLASH.+".toRegex())
+                        }
+                        ?.replace(SLASH, "")
                 } else if (path.matches("$ROUTE_RECAP.*".toRegex()) && Feature.enabled("recap")) {
                     it.getQueryParameter("course_id")
                 } else null
@@ -43,13 +66,21 @@ object DeepLinkingUtil {
         }
     }
 
+    /**
+     * Only matches item root path /courses/{course_id}/items/{item_id}
+     */
     fun getItemIdentifier(path: String?): String? {
         return path?.let {
             if (it.matches("$ROUTE_COURSES$SLASH..*$ROUTE_COURSE_ITEMS$SLASH..*".toRegex())) {
                 it
                     .replaceBefore(ROUTE_COURSE_ITEMS, "")
                     .replace(ROUTE_COURSE_ITEMS, "")
-                    .replace(SLASH, "")
+                    .replaceFirst(SLASH, "")
+                    // leaves any /something at the end
+                    .takeUnless {
+                        it.matches(".+$SLASH.+".toRegex())
+                    }
+                    ?.replace(SLASH, "")
             } else null
         }
     }

--- a/app/src/main/java/de/xikolo/utils/DeepLinkingUtil.kt
+++ b/app/src/main/java/de/xikolo/utils/DeepLinkingUtil.kt
@@ -35,7 +35,7 @@ object DeepLinkingUtil {
      * Ignores:
      * Invalid action /courses/{course_id}/something_invalid
      * Invalid action path /courses/{course_id}/resume/something
-     * Item sub paths /courses/{course_id}/items/{item_id]/something
+     * Item sub paths /courses/{course_id}/items/{item_id}/something
      */
     fun getCourseIdentifier(uri: Uri?): String? {
         return uri?.let {


### PR DESCRIPTION
The matching has been concretized and the parsing has been fixed. Tests have been added accordingly.

Note: When the function returns `null`, it means the link cannot be handled by the app.

Fixes #260 