### PR TITLE
Fix Deeplink Navigation

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -265,7 +265,14 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             android.R.id.home    -> {
-                NavUtils.navigateUpFromSameTask(this)
+                if (supportFragmentManager.backStackEntryCount > 0) {
+                    NavUtils.navigateUpFromSameTask(this)
+                } else {
+                    startActivity(
+                        NavUtils.getParentActivityIntent(this)
+                    )
+                    finish()
+                }
                 return true
             }
             R.id.action_share    -> {

--- a/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
@@ -220,8 +220,8 @@ class MainActivity : ViewModelActivity<NavigationViewModel>(), NavigationView.On
     override fun onBackPressed() {
         if (!drawerLayout.isDrawerOpen(GravityCompat.START)) {
             if (supportFragmentManager.backStackEntryCount == 1 ||
-                (UserManager.isAuthorized
-                    && navigationView.checkedItem?.itemId == R.id.navigation_my_courses) ||
+                (UserManager.isAuthorized &&
+                    navigationView.checkedItem?.itemId == R.id.navigation_my_courses) ||
                 (!UserManager.isAuthorized &&
                     navigationView.checkedItem?.itemId == R.id.navigation_all_courses)
             ) {

--- a/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
@@ -219,10 +219,12 @@ class MainActivity : ViewModelActivity<NavigationViewModel>(), NavigationView.On
 
     override fun onBackPressed() {
         if (!drawerLayout.isDrawerOpen(GravityCompat.START)) {
-            if ((UserManager.isAuthorized
-                    && navigationView.checkedItem?.itemId == R.id.navigation_my_courses)
-                || (!UserManager.isAuthorized &&
-                    navigationView.checkedItem?.itemId == R.id.navigation_all_courses)) {
+            if (supportFragmentManager.backStackEntryCount == 1 ||
+                (UserManager.isAuthorized
+                    && navigationView.checkedItem?.itemId == R.id.navigation_my_courses) ||
+                (!UserManager.isAuthorized &&
+                    navigationView.checkedItem?.itemId == R.id.navigation_all_courses)
+            ) {
                 finish()
             } else if (supportFragmentManager.backStackEntryCount > 1) {
                 supportFragmentManager.popBackStack()


### PR DESCRIPTION
Fixes the navigation inside the app when led there through deep links.

- `ALL_COURSES`, `MY_COURSES`, `NEWS`: Pressing back after a deeplink left a blank screen. Fixed by also finishing the app when there is only one backstack item (the initial blank activity screen).
- Course deeplinks: Navigating up and back closed the app because of a missing backstack. Back keeps this behavior but on up navigation, the `MainActivity` is now started. 

I discovered #269 but left it to the future as it is also ViewPager-related and might introduce bugs.