### PR TITLE
Replace Bypass with Markwon as used markdown library

### DIFF
--- a/app/dependencies.gradle.kts
+++ b/app/dependencies.gradle.kts
@@ -43,7 +43,8 @@ dependencies {
 
     // user interface
     implementation("de.psdev.licensesdialog:licensesdialog:2.1.0")
-    implementation("com.github.Commit451:bypasses:1.1.0")
+    implementation("io.noties.markwon:core:4.5.1")
+    implementation("io.noties.markwon:image-glide:4.5.1")
     implementation("com.github.rubensousa:previewseekbar:3.0.0")
 
     // view binding

--- a/app/dependencies.gradle.kts
+++ b/app/dependencies.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation("de.psdev.licensesdialog:licensesdialog:2.1.0")
     implementation("io.noties.markwon:core:4.5.1")
     implementation("io.noties.markwon:image-glide:4.5.1")
+    implementation("io.noties.markwon:ext-tables:4.5.1")
     implementation("com.github.rubensousa:previewseekbar:3.0.0")
 
     // view binding

--- a/app/dependencies.gradle.kts
+++ b/app/dependencies.gradle.kts
@@ -43,10 +43,17 @@ dependencies {
 
     // user interface
     implementation("de.psdev.licensesdialog:licensesdialog:2.1.0")
-    implementation("io.noties.markwon:core:4.5.1")
-    implementation("io.noties.markwon:image-glide:4.5.1")
-    implementation("io.noties.markwon:ext-tables:4.5.1")
     implementation("com.github.rubensousa:previewseekbar:3.0.0")
+
+    // markdown
+    val markwonVersion = "4.5.1"
+    implementation("io.noties.markwon:core:$markwonVersion")
+    implementation("io.noties.markwon:ext-latex:$markwonVersion")
+    implementation("io.noties.markwon:ext-strikethrough:$markwonVersion")
+    implementation("io.noties.markwon:ext-tables:$markwonVersion")
+    implementation("io.noties.markwon:ext-tasklist:$markwonVersion")
+    implementation("io.noties.markwon:html:$markwonVersion")
+    implementation("io.noties.markwon:image-glide:$markwonVersion")
 
     // view binding
     val butterknifeVersion = "10.2.1"

--- a/app/src/main/java/de/xikolo/utils/extensions/TextViewExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/TextViewExtensions.kt
@@ -41,7 +41,6 @@ fun <T : TextView> T.setMarkdownText(markdown: String?) {
             return url
         }
 
-        val glide = Glide.with(context)
         val formatter = Markwon.builder(context)
             .usePlugin(MarkwonInlineParserPlugin.create())
             .usePlugin(JLatexMathPlugin.create(textSize))
@@ -51,6 +50,8 @@ fun <T : TextView> T.setMarkdownText(markdown: String?) {
             .usePlugin(HtmlPlugin.create())
             .usePlugin(
                 GlideImagesPlugin.create(object : GlideImagesPlugin.GlideStore {
+                    private val glide = Glide.with(context)
+
                     override fun cancel(target: Target<*>) {
                         glide.clear(target)
                     }

--- a/app/src/main/java/de/xikolo/utils/extensions/TextViewExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/TextViewExtensions.kt
@@ -12,6 +12,7 @@ import de.xikolo.config.Config
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.core.MarkwonTheme
+import io.noties.markwon.ext.tables.TablePlugin
 import io.noties.markwon.image.AsyncDrawable
 import io.noties.markwon.image.glide.GlideImagesPlugin
 import java.net.MalformedURLException
@@ -35,19 +36,23 @@ fun <T : TextView> T.setMarkdownText(markdown: String?) {
             return url
         }
 
+        val glide = Glide.with(context)
         val formatter = Markwon.builder(context)
             .usePlugin(
                 GlideImagesPlugin.create(object : GlideImagesPlugin.GlideStore {
                     override fun cancel(target: Target<*>) {
-                        Glide.with(context).clear(target)
+                        glide.clear(target)
                     }
 
                     override fun load(drawable: AsyncDrawable): RequestBuilder<Drawable> {
-                        return Glide.with(context).load(
+                        return glide.load(
                             getAbsoluteUrl(drawable.destination)
                         )
                     }
                 })
+            )
+            .usePlugin(
+                TablePlugin.create(context)
             )
             .usePlugin(
                 object : AbstractMarkwonPlugin() {

--- a/app/src/main/java/de/xikolo/utils/extensions/TextViewExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/TextViewExtensions.kt
@@ -12,9 +12,14 @@ import de.xikolo.config.Config
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.core.MarkwonTheme
+import io.noties.markwon.ext.latex.JLatexMathPlugin
+import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
 import io.noties.markwon.ext.tables.TablePlugin
+import io.noties.markwon.ext.tasklist.TaskListPlugin
+import io.noties.markwon.html.HtmlPlugin
 import io.noties.markwon.image.AsyncDrawable
 import io.noties.markwon.image.glide.GlideImagesPlugin
+import io.noties.markwon.inlineparser.MarkwonInlineParserPlugin
 import java.net.MalformedURLException
 import java.net.URI
 import java.net.URISyntaxException
@@ -38,6 +43,12 @@ fun <T : TextView> T.setMarkdownText(markdown: String?) {
 
         val glide = Glide.with(context)
         val formatter = Markwon.builder(context)
+            .usePlugin(MarkwonInlineParserPlugin.create())
+            .usePlugin(JLatexMathPlugin.create(textSize))
+            .usePlugin(StrikethroughPlugin.create())
+            .usePlugin(TablePlugin.create(context))
+            .usePlugin(TaskListPlugin.create(context))
+            .usePlugin(HtmlPlugin.create())
             .usePlugin(
                 GlideImagesPlugin.create(object : GlideImagesPlugin.GlideStore {
                     override fun cancel(target: Target<*>) {
@@ -50,9 +61,6 @@ fun <T : TextView> T.setMarkdownText(markdown: String?) {
                         )
                     }
                 })
-            )
-            .usePlugin(
-                TablePlugin.create(context)
             )
             .usePlugin(
                 object : AbstractMarkwonPlugin() {

--- a/app/src/main/java/de/xikolo/utils/extensions/TextViewExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/TextViewExtensions.kt
@@ -1,23 +1,19 @@
 package de.xikolo.utils.extensions
 
-import `in`.uncod.android.bypass.Bypass
-import android.content.res.Resources
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
-import android.net.Uri
-import android.os.AsyncTask
 import android.text.SpannableString
 import android.text.method.LinkMovementMethod
 import android.text.style.URLSpan
-import android.util.Log
 import android.widget.TextView
-import de.xikolo.App
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestBuilder
+import com.bumptech.glide.request.target.Target
 import de.xikolo.config.Config
-import de.xikolo.config.GlideApp
-import de.xikolo.config.GlideRequests
-import java.lang.ref.WeakReference
+import io.noties.markwon.AbstractMarkwonPlugin
+import io.noties.markwon.Markwon
+import io.noties.markwon.core.MarkwonTheme
+import io.noties.markwon.image.AsyncDrawable
+import io.noties.markwon.image.glide.GlideImagesPlugin
 import java.net.MalformedURLException
 import java.net.URI
 import java.net.URISyntaxException
@@ -25,138 +21,65 @@ import java.net.URL
 
 fun <T : TextView> T.setMarkdownText(markdown: String?) {
     if (markdown != null) {
-        val bypass = Bypass(App.instance)
-        val imageGetter = BypassGlideImageGetter(this, GlideApp.with(this.context))
-        val spannable = bypass.markdownToSpannable(markdown, imageGetter)
+        fun getAbsoluteUrl(url: String): String {
+            try {
+                val uri = URI(url)
+                if (!uri.isAbsolute) {
+                    return URL(URL(Config.HOST_URL), url).toString()
+                }
+            } catch (e: URISyntaxException) {
+                return url
+            } catch (e: MalformedURLException) {
+                return url
+            }
+            return url
+        }
 
-        text = spannable
+        val formatter = Markwon.builder(context)
+            .usePlugin(
+                GlideImagesPlugin.create(object : GlideImagesPlugin.GlideStore {
+                    override fun cancel(target: Target<*>) {
+                        Glide.with(context).clear(target)
+                    }
+
+                    override fun load(drawable: AsyncDrawable): RequestBuilder<Drawable> {
+                        return Glide.with(context).load(
+                            getAbsoluteUrl(drawable.destination)
+                        )
+                    }
+                })
+            )
+            .usePlugin(
+                object : AbstractMarkwonPlugin() {
+                    override fun configureTheme(builder: MarkwonTheme.Builder) {
+                        // remove heading underline
+                        builder.headingBreakHeight(0)
+                    }
+                }
+            )
+            .build()
+
+        formatter.setMarkdown(this, markdown)
         movementMethod = LinkMovementMethod.getInstance()
 
-        val current = text as SpannableString
-        val spans = current.getSpans(0, current.length, URLSpan::class.java)
-
-        for (span in spans) {
-            val start = current.getSpanStart(span)
-            val end = current.getSpanEnd(span)
-            current.removeSpan(span)
-            current.setSpan(URLSpanFix(span.url), start, end, 0)
+        (text as SpannableString).apply {
+            getSpans(0, length, URLSpan::class.java).forEach {
+                val start = getSpanStart(it)
+                val end = getSpanEnd(it)
+                removeSpan(it)
+                setSpan(
+                    object : URLSpan(it.url) {
+                        override fun getURL(): String {
+                            return getAbsoluteUrl(super.getURL())
+                        }
+                    },
+                    start,
+                    end,
+                    0
+                )
+            }
         }
     } else {
         text = markdown
     }
-}
-
-private class URLSpanFix internal constructor(url: String) : URLSpan(url) {
-
-    override fun getURL(): String {
-        try {
-            val uri = URI(super.getURL())
-
-            if (!uri.isAbsolute) {
-                return URL(URL(Config.HOST_URL), super.getURL()).toString()
-            }
-        } catch (e: URISyntaxException) {
-            return super.getURL()
-        } catch (e: MalformedURLException) {
-            return super.getURL()
-        }
-
-        return super.getURL()
-    }
-
-}
-
-// taken from https://github.com/Commit451/BypassGlideImageGetter and migrated to glide v4
-private class BypassGlideImageGetter internal constructor(textView: TextView, private val glideRequests: GlideRequests) : Bypass.ImageGetter {
-
-    companion object {
-        val TAG: String = BypassGlideImageGetter::class.java.simpleName
-    }
-
-    private val textViewWeakReference: WeakReference<TextView> = WeakReference(textView)
-
-    private var maxWidth = -1
-
-    override fun getDrawable(source: String): Drawable {
-
-        val result = BitmapDrawablePlaceHolder()
-
-        object : AsyncTask<Void, Void, Bitmap>() {
-
-            override fun doInBackground(vararg meh: Void): Bitmap? {
-                var uri = Uri.parse(source)
-                if (uri.isRelative) {
-                    uri = Uri.Builder()
-                        .scheme("https")
-                        .authority(Config.HOST)
-                        .path(uri.path)
-                        .query(uri.query)
-                        .build()
-                }
-                try {
-                    return glideRequests
-                        .asBitmap()
-                        .load(uri)
-                        .centerCrop()
-                        .noPlaceholders()
-                        .dontAnimate()
-                        .submit()
-                        .get()
-                } catch (e: Exception) {
-                    Log.e(TAG, e.message, e)
-                    return null
-                }
-
-            }
-
-            override fun onPostExecute(bitmap: Bitmap) {
-                val textView = textViewWeakReference.get() ?: return
-                try {
-                    if (maxWidth == -1) {
-                        val horizontalPadding = textView.paddingLeft + textView.paddingRight
-                        maxWidth = textView.measuredWidth - horizontalPadding
-                        if (maxWidth == 0) {
-                            maxWidth = Integer.MAX_VALUE
-                        }
-                    }
-
-                    val drawable = BitmapDrawable(textView.resources, bitmap)
-                    val aspectRatio = 1.0 * drawable.intrinsicWidth / drawable.intrinsicHeight
-
-                    // real image width in pixel scaled based on screen density
-                    val scaledWidth = Math.round(drawable.intrinsicWidth * Resources.getSystem().displayMetrics.density)
-
-                    val width = Math.min(maxWidth, scaledWidth)
-                    val height = (width / aspectRatio).toInt()
-
-                    drawable.setBounds(0, 0, width, height)
-
-                    result.drawable = drawable
-                    result.setBounds(0, 0, width, height)
-
-                    // invalidate() doesn't work correctly...
-                    textView.text = textView.text
-                } catch (e: Exception) {
-                    Log.e(TAG, e.message, e)
-                }
-
-            }
-
-        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR)
-
-        return result
-    }
-
-    @Suppress("DEPRECATION")
-    internal class BitmapDrawablePlaceHolder : BitmapDrawable() {
-
-        var drawable: Drawable? = null
-
-        override fun draw(canvas: Canvas) {
-            if (drawable != null) {
-                drawable?.draw(canvas)
-            }
-        }
-    }
-
 }

--- a/app/src/main/res/layout/fragment_course_description.xml
+++ b/app/src/main/res/layout/fragment_course_description.xml
@@ -8,7 +8,7 @@
     <RelativeLayout
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/activity_horizontal_margin">
+        android:paddingBottom="@dimen/content_horizontal_margin">
 
         <LinearLayout
             android:id="@+id/layout_header"

--- a/app/src/main/res/raw/notices.xml
+++ b/app/src/main/res/raw/notices.xml
@@ -54,15 +54,9 @@
         <license>Apache Software License 2.0</license>
     </notice>
     <notice>
-        <name>Bypass</name>
-        <url>https://github.com/Uncodin/bypass/</url>
-        <copyright>Copyright (c) 2015 Uncodin</copyright>
-        <license>Apache Software License 2.0</license>
-    </notice>
-    <notice>
-        <name>Bypasses</name>
-        <url>https://github.com/Commit451/bypasses/</url>
-        <copyright>Copyright (c) 2017 Commit 451</copyright>
+        <name>Markwon</name>
+        <url>https://github.com/noties/Markwon/</url>
+        <copyright>Copyright (c) 2019 Dimitry Ivanov</copyright>
         <license>Apache Software License 2.0</license>
     </notice>
     <notice>


### PR DESCRIPTION
Bypass as our markdown library was not well maintained and required some glue code to work with Glide.
[Markwon](https://github.com/noties/Markwon) is well maintained and based on [commonmark](https://github.com/atlassian/commonmark-java) by Atlassian. It supports Glide and custom styling.

There are only subtle changes in styling such as bullet point size. Markwon would render an underline under headings, which I removed (to match the web). Is there a xikolo markdown reference to compare our rendered content to the web rendered?

Probably 
Fixes #264 
Fixes #266 
Fixes #267 

(I also added a larger padding to the bottom of the course description to better support devices with rounded edges)