### PR TITLE
Locale LanguageFilter translation implemented

### DIFF
--- a/app/src/main/java/de/xikolo/utils/LanguageUtil.kt
+++ b/app/src/main/java/de/xikolo/utils/LanguageUtil.kt
@@ -1,18 +1,34 @@
 package de.xikolo.utils
 
+import android.content.Context
 import java.util.Locale
 
 object LanguageUtil {
+    var deviceLanguage: String = Locale.getDefault().language.takeIf { it != "zh" } ?: "cn"
+
     @OptIn(ExperimentalStdlibApi::class)
     fun toNativeName(tag: String): String {
-        val languageTag =
-            if (tag == "cn") { // work-around for bug in the backend
-                "zh"
-            } else {
-                tag
-            }
+        val languageTag = correctLanguageTag(tag)
 
         val locale = Locale.forLanguageTag(languageTag)
         return locale.getDisplayLanguage(locale).capitalize(locale)
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    fun toLocaleName(context: Context, tag: String): String {
+        val languageTag = correctLanguageTag(tag)
+        val locale = Locale.forLanguageTag(languageTag)
+        val deviceLocale = Locale.getDefault()
+
+        return locale.getDisplayLanguage(deviceLocale).capitalize(locale)
+    }
+
+    private fun correctLanguageTag(tag: String): String {
+        // work-around for wrong chinese API locale in backend
+        return if (tag == "cn") {
+            "zh"
+        } else {
+            tag
+        }
     }
 }

--- a/app/src/main/java/de/xikolo/views/CourseFilterView.kt
+++ b/app/src/main/java/de/xikolo/views/CourseFilterView.kt
@@ -9,7 +9,6 @@ import de.xikolo.config.Feature
 import de.xikolo.models.dao.ChannelDao
 import de.xikolo.models.dao.CourseDao
 import de.xikolo.utils.LanguageUtil
-import java.util.*
 
 class CourseFilterView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyle: Int = 0) : LinearLayoutCompat(context, attrs, defStyle) {
 
@@ -46,10 +45,8 @@ class CourseFilterView @JvmOverloads constructor(context: Context, attrs: Attrib
         val classifierKeyList = mutableListOf<String>()
         val classifierTitleList = mutableListOf<String>()
 
-        var deviceLanguage = Locale.getDefault().language
-        if (deviceLanguage == "zh") { // workaround for wrong chinese API locale
-            deviceLanguage = "cn"
-        }
+        val deviceLanguage = LanguageUtil.deviceLanguage
+
         val languages = CourseDao.Unmanaged.languages()
             .sortedBy {
                 LanguageUtil.toNativeName(it)
@@ -85,7 +82,7 @@ class CourseFilterView @JvmOverloads constructor(context: Context, attrs: Attrib
             val options: List<Pair<String, String>> = when (classifierKey) {
                 context.getString(R.string.course_filter_classifier_language) -> {
                     languages.map {
-                        Pair(it, LanguageUtil.toNativeName(it))
+                        Pair(it, LanguageUtil.toNativeName(it) + " (" + LanguageUtil.toLocaleName(context, it) + ")")
                     }
                 }
                 context.getString(R.string.course_filter_classifier_channel)  -> {


### PR DESCRIPTION
Fixes #247 

Changes added to support a translation of course languages to the locale language. The format is nativeLanguage (localLanguage) f.e. Espagnol (Spanisch). Additionally the `LanguageUtil` was cleaned up.

<img src="https://user-images.githubusercontent.com/38314662/92375270-2ff3f580-f101-11ea-926d-6fbba485ec07.png" width=300px/>