### PR TITLE
Possible fix for #265 Realm: IllegalStateException

### DIFF
--- a/app/src/main/java/de/xikolo/models/dao/VideoDao.kt
+++ b/app/src/main/java/de/xikolo/models/dao/VideoDao.kt
@@ -3,16 +3,16 @@ package de.xikolo.models.dao
 import de.xikolo.extensions.asCopy
 import de.xikolo.models.Video
 import de.xikolo.models.dao.base.BaseDao
+import de.xikolo.network.sync.Local
 import io.realm.Realm
 import io.realm.kotlin.where
 
 class VideoDao(realm: Realm) : BaseDao<Video>(Video::class, realm) {
 
     fun updateProgress(video: Video, position: Int) {
-        realm.executeTransaction {
-            video.progress = position
-            it.copyToRealmOrUpdate(video)
-        }
+        Local.Update.with<Video>(video.id)
+            .setBeforeCommitCallback { _, model -> model.progress = position }
+            .run()
     }
 
     class Unmanaged {

--- a/app/src/main/java/de/xikolo/viewmodels/section/CourseItemsViewModel.kt
+++ b/app/src/main/java/de/xikolo/viewmodels/section/CourseItemsViewModel.kt
@@ -24,11 +24,6 @@ class CourseItemsViewModel(courseId: String, sectionId: String) : BaseViewModel(
     }
 
     fun markItemVisited(item: Item) {
-        realm.executeTransaction {
-            item.visited = true
-            it.copyToRealmOrUpdate(item)
-        }
-
         UpdateItemVisitedJob.schedule(item.id)
     }
 


### PR DESCRIPTION
This exception occurred when asynchronous queries were made within a Realm transaction, which is forbidden.
The exception mostly occurred when setting the `visited` state of an Item. Transaction were created manually there, but I do not know why beacuse `UpdateItemVisitedJob.schedule()` also sets the visited state (but via `Sync`, which did not create errors).
I also used `Sync` in another occurrence of manual Realm transactions.

Fixes #265 