### PR TITLE
Reload course model on CourseActivity refresh

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -265,7 +265,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            android.R.id.home    -> {
+            android.R.id.home -> {
                 if (supportFragmentManager.backStackEntryCount > 0) {
                     NavUtils.navigateUpFromSameTask(this)
                 } else {
@@ -276,7 +276,11 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
                 }
                 return true
             }
-            R.id.action_share    -> {
+            R.id.action_refresh -> {
+                viewModel.onRefresh()
+                return true
+            }
+            R.id.action_share -> {
                 shareCourseLink(courseId!!)
                 return true
             }
@@ -286,7 +290,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
                 dialog.show(supportFragmentManager, UnenrollDialog.TAG)
                 return true
             }
-            R.id.course_dates    -> {
+            R.id.course_dates -> {
                 val dialog = CourseDateListDialogAutoBundle.builder(courseId!!).build()
                 dialog.show(supportFragmentManager, UnenrollDialog.TAG)
                 return true


### PR DESCRIPTION
I was trying to reproduce the bug of #284 but couldn't, because it had already been fixed in #279. So I guess the bugs only occurred in app version 3.5. #279 states `CourseActivity: Our workaround was to observe the course only once and to ignore changes resulting e.g. from enrollments (resulting in bugs like #269).`. This also included changes in course area states such as course accessibility, because no observer would be active in the activity, resulting in not setting it up again when the user refreshed (and possibly always operating on outdated data that is returned on the first observe). #279 introduced such an observer which sets up the course when the database model changes. When only the tabs "Description" and "Certificates" are displayed, both of their fragments fetch the course model on refresh, which means any refresh in them also refreshes the activity (which is convenient). Other fragments such as "Learnings" do not do this. As an enhancement I made the activity also react to clicking "Refresh" in the menu.

I tested the behavior by manually altering the value of `accessible` in the `Course.JsonModel` in the `GetCourseJob` and applying changes to the activity without restarting the app. It rendered following behavior:

<img width="300" src="https://user-images.githubusercontent.com/26904189/95877735-b640ce80-0d74-11eb-9d63-f5f41f114684.gif"/>

Fixes #284 
