### PR TITLE
Allow back navigation in Discussions WebView

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -33,6 +33,7 @@ import de.xikolo.controllers.dialogs.UnenrollDialog
 import de.xikolo.controllers.helper.CourseArea
 import de.xikolo.controllers.login.LoginActivityAutoBundle
 import de.xikolo.controllers.section.CourseItemsActivityAutoBundle
+import de.xikolo.controllers.webview.WebViewFragment
 import de.xikolo.controllers.webview.WebViewFragmentAutoBundle
 import de.xikolo.extensions.observe
 import de.xikolo.extensions.observeOnce
@@ -330,6 +331,15 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
         super.onActivityResult(requestCode, resultCode, data)
     }
 
+    override fun onBackPressed() {
+        val webViewFragment =
+            (viewPager.adapter as CoursePagerAdapter).getFragmentAt(viewPager.currentItem)
+                as? WebViewFragment
+        if (webViewFragment?.onBack() != true) {
+            super.onBackPressed()
+        }
+    }
+
     private fun setAreaState(state: CourseArea.State) {
         areaState = state
         viewPager.adapter?.notifyDataSetChanged()
@@ -539,6 +549,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
                         Config.HOST_URL + Config.COURSES +
                             courseIdentifier + "/" + Config.DISCUSSIONS
                     )
+                        .allowBack(true)
                         .inAppLinksEnabled(true)
                         .externalLinksEnabled(false)
                         .build()

--- a/app/src/main/java/de/xikolo/controllers/webview/WebViewFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/webview/WebViewFragment.kt
@@ -35,6 +35,9 @@ class WebViewFragment : NetworkStateFragment() {
     @AutoBundleField(required = false)
     var externalLinksEnabled: Boolean = false
 
+    @AutoBundleField(required = false)
+    var allowBack: Boolean = false
+
     private var contentView: View? = null
 
     private lateinit var webViewHelper: WebViewHelper
@@ -91,8 +94,15 @@ class WebViewFragment : NetworkStateFragment() {
                 contentView = null
                 mutableContextWrapper = null
             }
-
         }
+    }
+
+    fun onBack(): Boolean {
+        val canGoBack = allowBack && webViewHelper.webView.canGoBack()
+        if (canGoBack) {
+            webViewHelper.webView.goBack()
+        }
+        return canGoBack
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {


### PR DESCRIPTION
When navigating the discussions tab in the `CourseActivity` and going back, instead of leading the user to the last visited page, the whole activity closes. It annoys myself and I also heard some user feedback on this. 
I included back handling for our `WebViewFragment` in general and enabled it only for discussuions for now (because e.g. for Recaps, no going back should be possible I guess.)