### PR TITLE
Refactor Intent opening logic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,10 @@
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="https" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="file" />
+        </intent>
     </queries>
 
     <application

--- a/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/channels/ChannelDetailsFragment.kt
@@ -1,7 +1,5 @@
 package de.xikolo.controllers.channels
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.FrameLayout
@@ -27,6 +25,7 @@ import de.xikolo.models.dao.CourseDao
 import de.xikolo.network.jobs.base.NetworkCode
 import de.xikolo.network.jobs.base.NetworkStateLiveData
 import de.xikolo.utils.MetaSectionList
+import de.xikolo.utils.extensions.openUrl
 import de.xikolo.viewmodels.channel.ChannelViewModel
 import de.xikolo.views.AutofitRecyclerView
 import de.xikolo.views.SpaceItemDecoration
@@ -226,8 +225,7 @@ class ChannelDetailsFragment : ViewModelFragment<ChannelViewModel>() {
     }
 
     private fun enterExternalCourse(course: Course) {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(course.externalUrl))
-        startActivity(intent)
+        activity?.openUrl(course.externalUrl)
     }
 
     private fun openLogin() {

--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -50,6 +50,7 @@ import de.xikolo.utils.IdUtil
 import de.xikolo.utils.LanalyticsUtil
 import de.xikolo.utils.ShortcutUtil
 import de.xikolo.utils.extensions.createChooser
+import de.xikolo.utils.extensions.openUrl
 import de.xikolo.utils.extensions.shareCourseLink
 import de.xikolo.utils.extensions.showToast
 import de.xikolo.viewmodels.course.CourseViewModel
@@ -499,8 +500,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
     }
 
     private fun enterExternalCourse(course: Course) {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(course.externalUrl))
-        startActivity(intent)
+        openUrl(course.externalUrl)
     }
 
     override fun onConnectivityChange(isOnline: Boolean) {

--- a/app/src/main/java/de/xikolo/controllers/dialogs/UnsupportedIntentDialog.kt
+++ b/app/src/main/java/de/xikolo/controllers/dialogs/UnsupportedIntentDialog.kt
@@ -1,0 +1,60 @@
+package de.xikolo.controllers.dialogs
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import com.yatatsu.autobundle.AutoBundleField
+import de.xikolo.R
+import de.xikolo.controllers.dialogs.base.BaseDialogFragment
+
+class UnsupportedIntentDialog : BaseDialogFragment() {
+
+    companion object {
+        @JvmField
+        val TAG: String = UnsupportedIntentDialog::class.java.simpleName
+    }
+
+    @AutoBundleField(required = false)
+    var fileMimeType: String? = null
+
+    var listener: Listener? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val message = getString(R.string.dialog_unsupported_intent_message) +
+            (
+                fileMimeType?.let {
+                    getString(R.string.dialog_unsupported_intent_message_file, it)
+                } ?: ""
+                )
+
+        val builder = AlertDialog.Builder(requireActivity())
+            .setTitle(R.string.dialog_unsupported_intent_title)
+            .setMessage(message)
+            .setNeutralButton(R.string.dialog_unsupported_intent_message_open_anyway) { _, _ ->
+                listener?.onOpenAnywayClicked()
+            }
+            .setNegativeButton(R.string.dialog_server_error_no) { _, _ ->
+                dismiss()
+            }
+            .apply {
+                if (fileMimeType != null) {
+                    setPositiveButton(
+                        R.string.dialog_unsupported_intent_message_open_path
+                    ) { _, _ ->
+                        listener?.onOpenPathClicked()
+                    }
+                }
+            }
+            .setCancelable(true)
+
+        val dialog = builder.create()
+        dialog.setCanceledOnTouchOutside(true)
+
+        return dialog
+    }
+
+    interface Listener {
+        fun onOpenPathClicked()
+        fun onOpenAnywayClicked()
+    }
+}

--- a/app/src/main/java/de/xikolo/controllers/helper/DownloadViewHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/DownloadViewHelper.kt
@@ -1,6 +1,5 @@
 package de.xikolo.controllers.helper
 
-import android.content.ActivityNotFoundException
 import android.os.Handler
 import android.os.Looper
 import android.view.View
@@ -155,14 +154,9 @@ class DownloadViewHelper(
             }
         }
 
+        // ToDo will be refactored in the HLS feature to hide the open button if openAction is null
         buttonOpenDownload.setOnClickListener {
-            if (download.openIntent != null) {
-                try {
-                    activity.startActivity(download.openIntent)
-                } catch (e: ActivityNotFoundException) {
-                    activity.showToast(R.string.toast_no_file_viewer_found)
-                }
-            } else {
+            download.openAction?.invoke(activity) ?: run {
                 activity.showToast(R.string.error_plain)
             }
         }

--- a/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/CourseListFragment.kt
@@ -1,7 +1,5 @@
 package de.xikolo.controllers.main
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
@@ -26,6 +24,7 @@ import de.xikolo.models.dao.CourseDao
 import de.xikolo.network.jobs.base.NetworkCode
 import de.xikolo.network.jobs.base.NetworkStateLiveData
 import de.xikolo.utils.MetaSectionList
+import de.xikolo.utils.extensions.openUrl
 import de.xikolo.viewmodels.main.CourseListViewModel
 import de.xikolo.views.AutofitRecyclerView
 import de.xikolo.views.CourseFilterView
@@ -101,8 +100,8 @@ class CourseListFragment : MainFragment<CourseListViewModel>() {
         }
 
         recyclerView.addItemDecoration(SpaceItemDecoration(
-            activity!!.resources.getDimensionPixelSize(R.dimen.card_horizontal_margin),
-            activity!!.resources.getDimensionPixelSize(R.dimen.card_vertical_margin),
+            requireActivity().resources.getDimensionPixelSize(R.dimen.card_horizontal_margin),
+            requireActivity().resources.getDimensionPixelSize(R.dimen.card_vertical_margin),
             false,
             object : SpaceItemDecoration.RecyclerViewInfo {
                 override fun isHeader(position: Int): Boolean {
@@ -265,19 +264,19 @@ class CourseListFragment : MainFragment<CourseListViewModel>() {
             showLoginRequired()
             openLogin()
         } else {
-            val intent = CourseActivityAutoBundle.builder().courseId(courseId).build(activity!!)
+            val intent =
+                CourseActivityAutoBundle.builder().courseId(courseId).build(requireActivity())
             startActivity(intent)
         }
     }
 
     private fun enterCourseDetails(courseId: String) {
-        val intent = CourseActivityAutoBundle.builder().courseId(courseId).build(activity!!)
+        val intent = CourseActivityAutoBundle.builder().courseId(courseId).build(requireActivity())
         startActivity(intent)
     }
 
     private fun enterExternalCourse(course: Course) {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(course.externalUrl))
-        startActivity(intent)
+        activity?.openUrl(course.externalUrl)
     }
 
     fun enroll(courseId: String) {
@@ -314,7 +313,7 @@ class CourseListFragment : MainFragment<CourseListViewModel>() {
     }
 
     private fun openLogin() {
-        val intent = LoginActivityAutoBundle.builder().build(activity!!)
+        val intent = LoginActivityAutoBundle.builder().build(requireActivity())
         startActivity(intent)
     }
 

--- a/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/main/MainActivity.kt
@@ -1,7 +1,6 @@
 package de.xikolo.controllers.main
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -31,6 +30,7 @@ import de.xikolo.utils.LanalyticsUtil
 import de.xikolo.utils.extensions.checkPlayServicesWithDialog
 import de.xikolo.utils.extensions.getStringArray
 import de.xikolo.utils.extensions.getTypedArray
+import de.xikolo.utils.extensions.openUrl
 import de.xikolo.viewmodels.main.NavigationViewModel
 
 class MainActivity : ViewModelActivity<NavigationViewModel>(), NavigationView.OnNavigationItemSelectedListener, MainActivityCallback {
@@ -263,9 +263,7 @@ class MainActivity : ViewModelActivity<NavigationViewModel>(), NavigationView.On
                     )
                     .apply {
                         setOnMenuItemClickListener {
-                            startActivity(
-                                Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                            )
+                            openUrl(url)
                             true
                         }
 

--- a/app/src/main/java/de/xikolo/download/DownloadItem.kt
+++ b/app/src/main/java/de/xikolo/download/DownloadItem.kt
@@ -1,6 +1,5 @@
 package de.xikolo.download
 
-import android.content.Intent
 import androidx.fragment.app.FragmentActivity
 
 abstract class DownloadItem<out F, out I : DownloadIdentifier> {
@@ -13,7 +12,7 @@ abstract class DownloadItem<out F, out I : DownloadIdentifier> {
 
     abstract val download: F?
 
-    abstract val openIntent: Intent?
+    abstract val openAction: ((FragmentActivity) -> Unit)?
 
     abstract var stateListener: StateListener?
 

--- a/app/src/main/java/de/xikolo/download/filedownload/FileDownloadItem.kt
+++ b/app/src/main/java/de/xikolo/download/filedownload/FileDownloadItem.kt
@@ -1,6 +1,5 @@
 package de.xikolo.download.filedownload
 
-import android.content.Intent
 import android.util.Log
 import androidx.fragment.app.FragmentActivity
 import de.xikolo.App
@@ -11,11 +10,11 @@ import de.xikolo.managers.PermissionManager
 import de.xikolo.models.DownloadAsset
 import de.xikolo.models.Storage
 import de.xikolo.states.PermissionStateLiveData
-import de.xikolo.utils.FileProviderUtil
 import de.xikolo.utils.LanalyticsUtil
 import de.xikolo.utils.extensions.buildWriteErrorMessage
 import de.xikolo.utils.extensions.createIfNotExists
 import de.xikolo.utils.extensions.internalStorage
+import de.xikolo.utils.extensions.open
 import de.xikolo.utils.extensions.preferredStorage
 import de.xikolo.utils.extensions.sdcardStorage
 import de.xikolo.utils.extensions.showToast
@@ -103,16 +102,9 @@ open class FileDownloadItem(
             return null
         }
 
-    override val openIntent: Intent?
-        get() {
-            return download?.let {
-                val target = Intent(Intent.ACTION_VIEW)
-                target.setDataAndType(FileProviderUtil.getUriForFile(it), mimeType)
-                target.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
-                target.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-
-                Intent.createChooser(target, null).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
+    override val openAction: ((FragmentActivity) -> Unit)?
+        get() = { activity ->
+            download?.open(activity, mimeType, false)
         }
 
     override var stateListener: StateListener? = null

--- a/app/src/main/java/de/xikolo/utils/extensions/IntentExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/IntentExtensions.kt
@@ -1,26 +1,33 @@
 package de.xikolo.utils.extensions
 
-import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.ACTION_GET_CONTENT
 import android.content.Intent.ACTION_VIEW
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Browser
+import androidx.fragment.app.FragmentActivity
+import de.xikolo.App
+import de.xikolo.R
 import de.xikolo.config.Config
+import de.xikolo.controllers.dialogs.UnsupportedIntentDialog
+import de.xikolo.controllers.dialogs.UnsupportedIntentDialogAutoBundle
+import de.xikolo.utils.FileProviderUtil
+import java.io.File
 
-
-fun <T : Intent> T.createChooser(context: Context, title: String? = null, packagesToHide: Array<String> = emptyArray()): Intent? {
-    val fakeIntent = Intent(ACTION_VIEW).apply { data = Uri.parse("http://someurl.com") }
+fun <T : Intent> T.createChooser(
+    context: Context,
+    title: String? = null,
+    packagesToHide: Array<String> = emptyArray()
+): Intent? {
     val resolveInfos = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        context.packageManager.queryIntentActivities(this, PackageManager.MATCH_ALL) +
-            context.packageManager.queryIntentActivities(fakeIntent, PackageManager.MATCH_ALL)
+        context.packageManager.queryIntentActivities(this, PackageManager.MATCH_ALL)
     } else {
-        context.packageManager.queryIntentActivities(this, 0) +
-            context.packageManager.queryIntentActivities(fakeIntent, 0)
+        context.packageManager.queryIntentActivities(this, 0)
     }
     val intents = resolveInfos
         .distinctBy {
@@ -46,19 +53,89 @@ fun <T : Intent> T.createChooser(context: Context, title: String? = null, packag
     }
 }
 
+private fun <T : Intent> T.open(
+    activity: FragmentActivity,
+    forceChooser: Boolean,
+    parentFile: File? = null
+): Boolean {
+    val chooserIntent = createChooser(App.instance)
+
+    fun startActivity(): Boolean {
+        return try {
+            activity.startActivity(
+                if (forceChooser) {
+                    chooserIntent
+                } else {
+                    this
+                }?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+            true
+        } catch (e: Exception) {
+            activity.showToast(R.string.error_plain)
+            false
+        }
+    }
+
+    return if (chooserIntent == null) {
+        val dialog = UnsupportedIntentDialogAutoBundle.builder()
+            .apply {
+                if (parentFile != null) {
+                    fileMimeType(type)
+                }
+            }
+            .build()
+        dialog.listener = object : UnsupportedIntentDialog.Listener {
+            override fun onOpenPathClicked() {
+                try {
+                    val fileManagerIntent = Intent(ACTION_GET_CONTENT)
+                    fileManagerIntent.setDataAndType(
+                        FileProviderUtil.getUriForFile(
+                            parentFile!!
+                        ),
+                        "vnd.android.document/directory"
+                    )
+                    fileManagerIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    activity.startActivity(fileManagerIntent)
+                } catch (e: Exception) {
+                    activity.showToast(R.string.dialog_unsupported_intent_error_no_file_manager)
+                }
+            }
+
+            override fun onOpenAnywayClicked() {
+                startActivity()
+            }
+        }
+        dialog.show(activity.supportFragmentManager, UnsupportedIntentDialog.TAG)
+        false
+    } else {
+        startActivity()
+    }
+}
+
+fun <T : File> T.open(
+    activity: FragmentActivity,
+    mimeType: String,
+    forceChooser: Boolean
+): Boolean {
+    val target = Intent(ACTION_VIEW)
+    target.setDataAndType(FileProviderUtil.getUriForFile(this), mimeType)
+    target.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
+    target.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+
+    return target.open(activity, forceChooser, parentFile)
+}
+
+fun <T : FragmentActivity> T.openUrl(url: String): Boolean {
+    val uri = try {
+        Uri.parse(url)
+    } catch (e: Exception) {
+        return false
+    }
+    return Intent(ACTION_VIEW, uri).open(this, false)
+}
+
 fun <T : Intent> T.includeAuthToken(token: String) {
     val headers = Bundle()
     headers.putString(Config.HEADER_AUTH, Config.HEADER_AUTH_VALUE_PREFIX + token)
     putExtra(Browser.EXTRA_HEADERS, headers)
-}
-
-fun <T : Context> T.openUrl(url: String): Boolean {
-    val intent = Intent(ACTION_VIEW)
-    intent.data = Uri.parse(url)
-    return try {
-        startActivity(intent)
-        true
-    } catch (E: ActivityNotFoundException) {
-        false
-    }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -139,6 +139,13 @@
     <string name="dialog_external_content_yes_peer">Öffnen</string>
     <string name="dialog_external_content_yes_always_peer">Öffnen und nicht erneut nachfragen</string>
 
+    <string name="dialog_unsupported_intent_title">Öffnen nicht möglich</string>
+    <string name="dialog_unsupported_intent_message">Es konnte keine Anwendung zum Ausführen dieser Aktion gefunden werden.</string>
+    <string name="dialog_unsupported_intent_message_file">\n\nEs wurde versucht folgender Dateityp zu öffnen: %1$s\nBitte installieren Sie eine Anwendung welche das Öffnen dieses Dateityps unterstützt.</string>
+    <string name="dialog_unsupported_intent_message_open_anyway">Trotzdem versuchen zu öffnen</string>
+    <string name="dialog_unsupported_intent_message_open_path">Versuchen im Dateimanager zu öffnen</string>
+    <string name="dialog_unsupported_intent_error_no_file_manager">Kein Dateimanager gefunden</string>
+
     <!-- -->
     <string name="title_activity_module">Module</string>
 
@@ -273,7 +280,6 @@
     <string name="toast_successful_logout">Erfolgreich abgemeldet.</string>
     <string name="toast_file_already_downloaded">Datei bereits heruntergeladen.</string>
     <string name="toast_no_external_write_access">Kein Schreibzugriff für %1$s.</string>
-    <string name="toast_no_file_viewer_found">Keine Anwendung zum Öffnen dieser Datei gefunden.</string>
     <string name="toast_pip_error">Die Anwendung konnte nicht in den Bild-im-Bild Modus wechseln.</string>
 
     <!-- -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -141,7 +141,7 @@
 
     <string name="dialog_unsupported_intent_title">Öffnen nicht möglich</string>
     <string name="dialog_unsupported_intent_message">Es konnte keine Anwendung zum Ausführen dieser Aktion gefunden werden.</string>
-    <string name="dialog_unsupported_intent_message_file">\n\nEs wurde versucht folgender Dateityp zu öffnen: %1$s\nBitte installieren Sie eine Anwendung welche das Öffnen dieses Dateityps unterstützt.</string>
+    <string name="dialog_unsupported_intent_message_file">\n\nEs wurde versucht folgenden Dateityp zu öffnen: %1$s\nBitte installieren Sie eine Anwendung, welche das Öffnen dieses Dateityps unterstützt.</string>
     <string name="dialog_unsupported_intent_message_open_anyway">Trotzdem versuchen zu öffnen</string>
     <string name="dialog_unsupported_intent_message_open_path">Versuchen im Dateimanager zu öffnen</string>
     <string name="dialog_unsupported_intent_error_no_file_manager">Kein Dateimanager gefunden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -139,6 +139,13 @@
     <string name="dialog_external_content_yes_peer">Abrir</string>
     <string name="dialog_external_content_yes_always_peer">Abrir y no volver a preguntarme</string>
 
+    <string name="dialog_unsupported_intent_title">No puede abrirse</string>
+    <string name="dialog_unsupported_intent_message">No se pudo detectar ninguna solicitud de ejecución de esta acción.</string>
+    <string name="dialog_unsupported_intent_message_file">\n\nIntentaste abrir el siguiente formato de archivo: %1$s\nPor favor, instale una aplicación que soporte la apertura de este tipo de archivos.</string>
+    <string name="dialog_unsupported_intent_message_open_anyway">Intenta abrir de todas formas</string>
+    <string name="dialog_unsupported_intent_message_open_path">Intenta abrir con un gestor de archivos</string>
+    <string name="dialog_unsupported_intent_error_no_file_manager">No se encontró ningún gestor de archivos</string>
+
     <!-- -->
     <string name="title_activity_module">Módulo</string>
 
@@ -272,7 +279,6 @@
     <string name="toast_successful_logout">La sesión se cerró adecuadamente.</string>
     <string name="toast_file_already_downloaded">Archivo ya descargado.</string>
     <string name="toast_no_external_write_access">No hay acceso de escritura para %1$s.</string>
-    <string name="toast_no_file_viewer_found">No se encontró ninguna aplicación para abrir este archivo.</string>
     <string name="toast_pip_error">La aplicación no pudo entrar en el modo Imagen en imagen.</string>
 
     <!-- -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -138,6 +138,13 @@
     <string name="dialog_external_content_yes_peer">Ouvrir</string>
     <string name="dialog_external_content_yes_always_peer">Ouvrir et ne plus poser cette question</string>
 
+    <string name="dialog_unsupported_intent_title">Ne peut être ouvert</string>
+    <string name="dialog_unsupported_intent_message">Aucune demande d\'exécution de cette action n\'a pu être détectée.</string>
+    <string name="dialog_unsupported_intent_message_file">\n\nVous avez essayé d\'ouvrir le format de fichier suivant : %1$s\nVeuillez installer une application qui prend en charge l\'ouverture de ce type de fichier.</string>
+    <string name="dialog_unsupported_intent_message_open_anyway">Essayez quand même d\'ouvrir</string>
+    <string name="dialog_unsupported_intent_message_open_path">Essayez d\'ouvrir avec un gestionnaire de fichiers</string>
+    <string name="dialog_unsupported_intent_error_no_file_manager">Aucun gestionnaire de fichiers trouvé</string>
+
     <!-- -->
     <string name="title_activity_module">Module</string>
 
@@ -271,7 +278,6 @@
     <string name="toast_successful_logout">Utilisateur déconnecté avec succès.</string>
     <string name="toast_file_already_downloaded">Fichier déjà téléchargé.</string>
     <string name="toast_no_external_write_access">Aucun accès en écriture %1$s.</string>
-    <string name="toast_no_file_viewer_found">Aucune application trouvée pour ouvrir le fichier.</string>
     <string name="toast_pip_error">L\'application n\'a pas pu entrer en mode incrustation d\'image.</string>
 
     <!-- -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -139,6 +139,13 @@
     <string name="dialog_external_content_yes_peer">Abrir</string>
     <string name="dialog_external_content_yes_always_peer">Abrir e não perguntar novamente</string>
 
+    <string name="dialog_unsupported_intent_title">Não pode ser aberto</string>
+    <string name="dialog_unsupported_intent_message">Não pôde ser detectado qualquer pedido para a execução desta acção.</string>
+    <string name="dialog_unsupported_intent_message_file">\n\nTentou abrir no seguinte formato de ficheiro: %1$s\nPor favor, instale uma aplicação que suporte a abertura deste tipo de ficheiro.</string>
+    <string name="dialog_unsupported_intent_message_open_anyway">Tente abrir de qualquer forma</string>
+    <string name="dialog_unsupported_intent_message_open_path">Tente abrir com um gestor de ficheiros</string>
+    <string name="dialog_unsupported_intent_error_no_file_manager">Não foi encontrado nenhum gestor de ficheiros</string>
+
     <!-- -->
     <string name="title_activity_module">Módulo</string>
 
@@ -272,7 +279,6 @@
     <string name="toast_successful_logout">Desconectado com sucesso.</string>
     <string name="toast_file_already_downloaded">Arquivo já baixado.</string>
     <string name="toast_no_external_write_access">Não há acesso à gravação para %1$s.</string>
-    <string name="toast_no_file_viewer_found">Nenhum aplicativo para abrir este arquivo encontrado.</string>
     <string name="toast_pip_error">O aplicativo não pôde entrar no modo Picture-in-Picture.</string>
 
     <!-- -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -139,6 +139,13 @@
     <string name="dialog_external_content_yes_peer">打开</string>
     <string name="dialog_external_content_yes_always_peer">打开并不\再提示</string>
 
+    <string name="dialog_unsupported_intent_title">不能打开</string>
+    <string name="dialog_unsupported_intent_message">没有发现执行该行动的申请。</string>
+    <string name="dialog_unsupported_intent_message_file">\n\n你试图打开以下文件格式。 %1$s\n请安装一个支持打开此文件类型的应用程序。</string>
+    <string name="dialog_unsupported_intent_message_open_anyway">无论如何都要打开</string>
+    <string name="dialog_unsupported_intent_message_open_path">尝试用文件管理器打开</string>
+    <string name="dialog_unsupported_intent_error_no_file_manager">没有找到文件管理器</string>
+
     <!-- -->
     <string name="title_activity_module">单元</string>
 
@@ -272,7 +279,6 @@
     <string name="toast_successful_logout">登出成功。</string>
     <string name="toast_file_already_downloaded">档案已下载。</string>
     <string name="toast_no_external_write_access">没有编写权限 %1$s。</string>
-    <string name="toast_no_file_viewer_found">找不到打开此文件的应用程序。</string>
     <string name="toast_pip_error">应用程序无法进入画中画模式。</string>
 
     <!-- -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,13 @@
     <string name="dialog_external_content_yes_peer">Open</string>
     <string name="dialog_external_content_yes_always_peer">Open and don\'t ask again</string>
 
+    <string name="dialog_unsupported_intent_title">Cannot be opened</string>
+    <string name="dialog_unsupported_intent_message">No application for executing this action could be detected.</string>
+    <string name="dialog_unsupported_intent_message_file">\n\nYou tried to open following file format: %1$s\nPlease install an application that supports opening this file type.</string>
+    <string name="dialog_unsupported_intent_message_open_anyway">Try opening anyway</string>
+    <string name="dialog_unsupported_intent_message_open_path">Try to open with a file manager</string>
+    <string name="dialog_unsupported_intent_error_no_file_manager">No file manager found</string>
+
     <!-- -->
     <string name="title_activity_module">Module</string>
 
@@ -274,7 +281,6 @@
     <string name="toast_successful_logout">Logged out successfully.</string>
     <string name="toast_file_already_downloaded">File already downloaded.</string>
     <string name="toast_no_external_write_access">No write access for %1$s.</string>
-    <string name="toast_no_file_viewer_found">No application to open this file found.</string>
     <string name="toast_pip_error">The application could not enter Picture-in-Picture mode.</string>
 
     <!-- -->


### PR DESCRIPTION
When calling [Intent].open() and no resolving Activity could be found, the `UnsupportedIntentDialog` is shown with a warning. The user has the option to "Open Anyway" (force open the intent) or if its a file, open its folder in the file manager.

<img src="https://user-images.githubusercontent.com/26904189/98344992-53a9be00-2014-11eb-9a2c-cadebe1ac2eb.png" width=250 />

Please have a look at the messages and approve / change them so I can translate them.

Fixes #287 
