### PR TITLE
Subtitle support for Cast

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -49,10 +49,10 @@
     </style>
 
     <array name="cast_expanded_controller_control_buttons">
-        <item>@id/cast_button_type_empty</item>
+        <item>@id/cast_button_type_closed_caption</item>
         <item>@id/cast_button_type_rewind_30_seconds</item>
+        <item>@id/cast_button_type_forward_30_seconds</item>
         <item>@id/cast_button_type_mute_toggle</item>
-        <item>@id/cast_button_type_empty</item>
     </array>
 
 </resources>


### PR DESCRIPTION
Adds a button for subtitle track selection.
To make the former 3-button layout (30s backward, play/pause, mute) symmetric, the 30s formward button has been added as well.
The layout now is (subtitles, 30s backward, play/pause, 30s forward, mute).

TODO:
- ~~testing~~
- ~~hiding button when no subtitles available?~~

Fixes #301 