### PR TITLE
Fix intent chooser component querying

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,21 +10,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 
-    <queries>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="http" />
-        </intent>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="https" />
-        </intent>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="file" />
-        </intent>
-    </queries>
-
     <application
         android:name=".App"
         android:allowBackup="false"

--- a/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
+++ b/app/src/main/java/de/xikolo/controllers/course/CourseActivity.kt
@@ -392,7 +392,7 @@ class CourseActivity : ViewModelActivity<CourseViewModel>(), UnenrollDialog.List
     private fun createChooserFromCurrentIntent() {
         intent?.let {
             Handler().postDelayed({
-                Intent(it.action, it.data).createChooser(this, null, arrayOf(this.packageName))?.let {
+                Intent(it.action, it.data).createChooser(this, null, true)?.let {
                     startActivity(it)
                 } ?: run {
                     showToast(R.string.error_plain)

--- a/app/src/main/java/de/xikolo/controllers/section/LtiExerciseFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/LtiExerciseFragment.kt
@@ -124,7 +124,7 @@ class LtiExerciseFragment : ViewModelFragment<LtiExerciseViewModel>() {
                 includeAuthToken(UserManager.token!!)
             }
             context?.let { context ->
-                intent.createChooser(context, null, arrayOf(context.packageName))?.let { intent ->
+                intent.createChooser(context, null, true)?.let { intent ->
                     startActivity(intent)
                 } ?: run {
                     showToast(R.string.error_plain)

--- a/app/src/main/java/de/xikolo/controllers/section/PeerAssessmentFragment.kt
+++ b/app/src/main/java/de/xikolo/controllers/section/PeerAssessmentFragment.kt
@@ -21,7 +21,11 @@ import de.xikolo.managers.UserManager
 import de.xikolo.models.Item
 import de.xikolo.models.PeerAssessment
 import de.xikolo.storages.ApplicationPreferences
-import de.xikolo.utils.extensions.*
+import de.xikolo.utils.extensions.createChooser
+import de.xikolo.utils.extensions.includeAuthToken
+import de.xikolo.utils.extensions.isPast
+import de.xikolo.utils.extensions.setMarkdownText
+import de.xikolo.utils.extensions.showToast
 import de.xikolo.viewmodels.section.PeerAssessmentViewModel
 
 class PeerAssessmentFragment : ViewModelFragment<PeerAssessmentViewModel>() {
@@ -123,7 +127,7 @@ class PeerAssessmentFragment : ViewModelFragment<PeerAssessmentViewModel>() {
                 includeAuthToken(UserManager.token!!)
             }
             context?.let { context ->
-                intent.createChooser(context, null, arrayOf(context.packageName))?.let { intent ->
+                intent.createChooser(context, null, true)?.let { intent ->
                     startActivity(intent)
                 } ?: run {
                     showToast(R.string.error_plain)


### PR DESCRIPTION
This should now ultimately fix our intent query issue.

Our main requirement was to hide the own app in Intent Choosers. Our approach was to explicitly specify the apps to show in the Chooser using the flag `Intent.EXTRA_INITIAL_INTENTS`, requiring the scan of all apps on the device (which does not function properly on Android 11). The soultion is to now exclude the components from our own app explicitly in the Chooser via the flag `Intent.EXTRA_EXCLUDE_COMPONENTS`. As this works only from N on, we use the old working logic for sub-N.
The only limitation now is that we cannot hide other apps than our own, but we did not use that functionality anyway.

For testing, better uninstall the production app (or set its intent opening settings to default).

Fixes #300 