### PR TITLE
Fix subtitle text in video settings

### DIFF
--- a/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
@@ -104,11 +104,13 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
             list.addView(
                 buildSettingsItem(
                     R.string.icon_subtitles,
-                    context.getString(R.string.video_settings_subtitles) + (currentVideoSubtitles?.let {
-                        "  " + context.getString(R.string.video_settings_separator) + "  " + LanguageUtil.toNativeName(
-                            it.language
-                        )
-                    } ?: ""),
+                    context.getString(R.string.video_settings_subtitles) + (
+                        currentVideoSubtitles?.let {
+                            "  " + context.getString(R.string.video_settings_separator) + "  " + LanguageUtil.toNativeName(
+                                it.language
+                            )
+                        } ?: ""
+                        ),
                     View.OnClickListener { clickListener.onSubtitleClick() },
                     false,
                     Config.FONT_MATERIAL

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
@@ -104,11 +104,11 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
             list.addView(
                 buildSettingsItem(
                     R.string.icon_subtitles,
-                    context.getString(R.string.video_settings_subtitles) + currentVideoSubtitles?.let {
+                    context.getString(R.string.video_settings_subtitles) + (currentVideoSubtitles?.let {
                         "  " + context.getString(R.string.video_settings_separator) + "  " + LanguageUtil.toNativeName(
                             it.language
                         )
-                    } ?: "",
+                    } ?: ""),
                     View.OnClickListener { clickListener.onSubtitleClick() },
                     false,
                     Config.FONT_MATERIAL

--- a/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
+++ b/app/src/main/java/de/xikolo/controllers/helper/VideoSettingsHelper.kt
@@ -106,9 +106,8 @@ class VideoSettingsHelper(private val context: Context, private val subtitles: L
                     R.string.icon_subtitles,
                     context.getString(R.string.video_settings_subtitles) + (
                         currentVideoSubtitles?.let {
-                            "  " + context.getString(R.string.video_settings_separator) + "  " + LanguageUtil.toNativeName(
-                                it.language
-                            )
+                            "  " + context.getString(R.string.video_settings_separator) +
+                                "  " + LanguageUtil.toNativeName(it.language)
                         } ?: ""
                         ),
                     View.OnClickListener { clickListener.onSubtitleClick() },


### PR DESCRIPTION
There was a bug introduced in https://github.com/openHPI/xikolo-android/commit/b56290c7ca8a00c9f9b9791fee2c2e32d9b81626 that appended a `null` to the subtitles text when no subtitles were selected. This has been fixed by adding proper parentheses.

<img width="400" src="https://user-images.githubusercontent.com/26904189/115585696-20aa6c80-a2cc-11eb-8a5b-0b5e95639212.jpg"/>
