### PR TITLE
Scale down images in Glide before displaying them

### DIFF
--- a/app/src/main/java/de/xikolo/utils/extensions/DisplayExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/DisplayExtensions.kt
@@ -8,6 +8,7 @@ import android.content.res.Configuration
 import android.graphics.Point
 import android.os.Build
 import android.util.DisplayMetrics
+import android.view.WindowManager
 
 val <T : Context> T.is7inchTablet: Boolean
     get() {
@@ -19,11 +20,19 @@ val <T : Context> T.is7inchTablet: Boolean
         return dpHeight >= 600 || dpWidth >= 600
     }
 
-val <T : Activity?> T.displaySize: Point
+val <T : Context> T.displaySize: Point
     get() {
-        val size = Point(0, 0)
-        this?.windowManager?.defaultDisplay?.getSize(size)
-        return size
+        val windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Point(
+                windowManager.currentWindowMetrics.bounds.width(),
+                windowManager.currentWindowMetrics.bounds.height()
+            )
+        } else {
+            val size = Point(0, 0)
+            windowManager.defaultDisplay.getRealSize(size)
+            size
+        }
     }
 
 val <T : Activity> T.videoThumbnailSize: Point

--- a/app/src/main/java/de/xikolo/utils/extensions/TextViewExtensions.kt
+++ b/app/src/main/java/de/xikolo/utils/extensions/TextViewExtensions.kt
@@ -50,16 +50,19 @@ fun <T : TextView> T.setMarkdownText(markdown: String?) {
             .usePlugin(HtmlPlugin.create())
             .usePlugin(
                 GlideImagesPlugin.create(object : GlideImagesPlugin.GlideStore {
-                    private val glide = Glide.with(context)
-
                     override fun cancel(target: Target<*>) {
-                        glide.clear(target)
+                        Glide.with(context).clear(target)
                     }
 
                     override fun load(drawable: AsyncDrawable): RequestBuilder<Drawable> {
-                        return glide.load(
-                            getAbsoluteUrl(drawable.destination)
-                        )
+                        return Glide.with(context)
+                            .load(getAbsoluteUrl(drawable.destination))
+                            .override(
+                                context.displaySize.x,
+                                Target.SIZE_ORIGINAL
+                            )
+                            .dontTransform()
+                            .fitCenter()
                     }
                 })
             )


### PR DESCRIPTION
The item from the Issue #309 did not make the app crash on my phone but it became very unresponsive because of the large (50 megapixel) images. This fix scales down images to a maximum width of the device width while keeping the aspect ratio.

Also `DisplayExtensions#displaySize` has been rewritten with Android 11 specific handling.

Please test whether this resolves your issue.


Fixes #309 