### PR TITLE
Fix unnecessary blank space in collapsing toolbar activities

### DIFF
--- a/app/src/main/res/layout/activity_blank_collapsing.xml
+++ b/app/src/main/res/layout/activity_blank_collapsing.xml
@@ -71,7 +71,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@color/background"
-            android:fitsSystemWindows="true"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
I did a trial-and-error search for the bug and found out that a single `android:fitsSystemWindows="true"` had to be removed.

Fixes #307